### PR TITLE
Fix worker pool lifecycle edge cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "bun run -F comlink-worker-pool-react -F comlink-worker-pool -F comlink-worker-pool-playground typecheck && bun run browser:typecheck",
 		"build": "bun run -F comlink-worker-pool-react -F comlink-worker-pool build",
 		"build:watch": "bun run -F comlink-worker-pool-react -F comlink-worker-pool build",
-		"test": "bun run -F comlink-worker-pool-react -F comlink-worker-pool test",
+		"test": "bun run -F comlink-worker-pool-react -F comlink-worker-pool -F comlink-worker-pool-playground test",
 		"test:exports": "node scripts/smoke-package-exports.cjs",
 		"test:packages": "bun run test:exports && publint packages/comlink-worker-pool && publint packages/comlink-worker-pool-react && attw --pack packages/comlink-worker-pool --profile strict && attw --pack packages/comlink-worker-pool-react --profile strict && node scripts/smoke-package-consumer.mjs",
 		"test:browser": "playwright test",

--- a/packages/comlink-worker-pool/src/WorkerPool.reentrancy.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.reentrancy.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, jest, test } from "bun:test";
+import { WorkerPool } from "./WorkerPool";
+
+type ReentrantApi = {
+	run(value: string): Promise<string>;
+};
+
+class ReentrantWorker extends EventTarget {
+	terminate(): void {}
+}
+
+afterEach(() => {
+	if (jest.isFakeTimers()) {
+		jest.clearAllTimers();
+		jest.useRealTimers();
+	}
+});
+
+describe("WorkerPool - reentrant scheduling", () => {
+	test("does not install a queue timer after reentrant cancellation", async () => {
+		jest.useFakeTimers({ now: 4_000 });
+		const controller = new AbortController();
+		const pool = new WorkerPool<ReentrantApi>({
+			size: 1,
+			queueTimeoutMs: 1_000,
+			taskTimeoutMs: false,
+			workerFactory: () => new ReentrantWorker() as unknown as Worker,
+			proxyFactory: () => ({ run: async (value) => value }),
+			onEvent: (event) => {
+				if (event.type === "task-queued") controller.abort();
+			},
+		});
+
+		await expect(
+			pool.run("run", ["cancelled"], { signal: controller.signal }),
+		).rejects.toMatchObject({ name: "WorkerTaskAbortedError" });
+		expect(jest.getTimerCount()).toBe(0);
+		await pool.close();
+	});
+});

--- a/packages/comlink-worker-pool/src/WorkerPool.robustness.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.robustness.test.ts
@@ -126,6 +126,24 @@ describe("WorkerPool - lifecycle robustness", () => {
 		pool.terminateAll();
 	});
 
+	test("preserves the proxy receiver when invoking methods", async () => {
+		const pool = new WorkerPool({
+			size: 1,
+			workerFactory: () => asWorker(new ControlledWorker()),
+			proxyFactory: () => ({
+				helper(): string {
+					return "receiver preserved";
+				},
+				run(): string {
+					return this.helper();
+				},
+			}),
+		});
+
+		await expect(pool.run("run", [])).resolves.toBe("receiver preserved");
+		await pool.close();
+	});
+
 	test("termination rejects active and queued work and ignores late completion", async () => {
 		const held = deferred<string>();
 		const workers: ControlledWorker[] = [];
@@ -367,6 +385,41 @@ describe("WorkerPool - lifecycle robustness", () => {
 		pool.terminateAll();
 	});
 
+	test("only classifies the task that reached its deadline as timed out", async () => {
+		const pool = new WorkerPool({
+			size: 1,
+			maxConcurrentTasksPerWorker: 2,
+			taskTimeoutMs: 60,
+			workerFactory: () => asWorker(new ControlledWorker()),
+			proxyFactory: () => ({
+				run: () => new Promise<number>(() => {}),
+			}),
+		});
+
+		const timedOut = pool.run("run", []);
+		await new Promise((resolve) => setTimeout(resolve, 30));
+		const sibling = pool.run("run", []);
+		const [timedOutResult, siblingResult] = await Promise.allSettled([
+			timedOut,
+			sibling,
+		]);
+
+		expect(timedOutResult).toMatchObject({
+			status: "rejected",
+			reason: expect.any(WorkerTaskTimeoutError),
+		});
+		expect(siblingResult).toMatchObject({
+			status: "rejected",
+			reason: expect.any(WorkerCrashedError),
+		});
+		expect(pool.getStats()).toMatchObject({
+			failedTasks: 1,
+			timedOutTasks: 1,
+		});
+
+		await pool.close();
+	});
+
 	test("task retirement is strict and never exceeds the physical size cap", async () => {
 		const firstTask = deferred<string>();
 		const workers: ControlledWorker[] = [];
@@ -454,6 +507,28 @@ describe("WorkerPool - lifecycle robustness", () => {
 		expect(workerCreations).toBe(0);
 		await expect(api.echo("ok")).resolves.toBe("ok");
 		pool.terminateAll();
+	});
+
+	test("isolates rejected promises returned by lifecycle callbacks", async () => {
+		const rejectAsync = () =>
+			Promise.reject(new Error("async observer failed"));
+		const pool = new WorkerPool({
+			size: 1,
+			terminationRetryAttempts: 0,
+			workerFactory: () => asWorker(new ControlledWorker()),
+			proxyFactory: () => ({ echo: async (value: string) => value }),
+			onEvent: rejectAsync,
+			onUpdateStats: rejectAsync,
+			onWorkerTerminationError: rejectAsync,
+			proxyCleanup: rejectAsync,
+			workerTerminator: () => {
+				throw new Error("termination failed");
+			},
+		});
+
+		await expect(pool.run("echo", ["ok"])).resolves.toBe("ok");
+		await expect(pool.close()).resolves.toMatchObject({ confirmed: false });
+		await flushMicrotasks();
 	});
 
 	test("default termination failure buffer is max(2, floor(size / 2))", async () => {

--- a/packages/comlink-worker-pool/src/WorkerPool.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.ts
@@ -16,6 +16,7 @@ import {
 	assertNonNegativeInteger,
 	assertPositiveDuration,
 	assertPositiveInteger,
+	isolateAsyncFailure,
 	monotonicNow,
 } from "./internal/lifecycle";
 import { type ScheduledTask, SchedulerQueue } from "./internal/scheduler";
@@ -396,7 +397,7 @@ export class WorkerPool<
 					exhausted: error.exhausted,
 				});
 				try {
-					options.onWorkerTerminationError?.(error);
+					isolateAsyncFailure(options.onWorkerTerminationError?.(error));
 				} catch {
 					// Failure observers are isolated from scheduler control flow.
 				}
@@ -634,7 +635,9 @@ export class WorkerPool<
 		item: ScheduledTask<TTask, TResult>,
 		timeoutMs: number | undefined,
 	): void {
-		if (timeoutMs === undefined) return;
+		if (timeoutMs === undefined || item.settled || !this.queue.contains(item)) {
+			return;
+		}
 		const deadline = monotonicNow() + timeoutMs;
 		const schedule = () => {
 			if (!this.queue.contains(item)) return;
@@ -836,7 +839,7 @@ export class WorkerPool<
 						`Worker proxy method ${String(item.task.method)} is not a function`,
 					);
 				}
-				return method(...item.task.args);
+				return Reflect.apply(method, worker.proxy, item.task.args);
 			})
 			.then(
 				(result) => this._completeTask(worker, item, true, result as TResult),
@@ -880,10 +883,15 @@ export class WorkerPool<
 	private _handleWorkerFailure(
 		worker: WorkerMetadata<TProxy, TTask, TResult>,
 		reason: unknown,
+		triggeringTask?: ScheduledTask<TTask, TResult>,
 	): void {
 		if (!this._containsWorker(worker)) return;
 		for (const item of [...worker.activeTasks]) {
-			this._settleTask(item, false, reason);
+			const taskReason =
+				triggeringTask !== undefined && item !== triggeringTask
+					? new WorkerCrashedError(worker.id, reason)
+					: reason;
+			this._settleTask(item, false, taskReason);
 		}
 		worker.activeTasks.clear();
 		this._removeWorker(
@@ -981,7 +989,11 @@ export class WorkerPool<
 				return;
 			}
 			item.timeout = undefined;
-			this._handleWorkerFailure(worker, new WorkerTaskTimeoutError(timeoutMs));
+			this._handleWorkerFailure(
+				worker,
+				new WorkerTaskTimeoutError(timeoutMs),
+				item,
+			);
 		};
 		item.timeout = setTimeout(
 			schedule,
@@ -1115,13 +1127,13 @@ export class WorkerPool<
 	private _cleanupProxy(proxy: TProxy): void {
 		try {
 			if (this.proxyCleanup) {
-				this.proxyCleanup(proxy);
+				isolateAsyncFailure(this.proxyCleanup(proxy));
 				return;
 			}
 			const releasable = proxy as TProxy & {
 				[releaseProxy]?: () => void;
 			};
-			releasable[releaseProxy]?.();
+			isolateAsyncFailure(releasable[releaseProxy]?.());
 		} catch {
 			// Cleanup must not strand queued work or other workers.
 		}
@@ -1172,7 +1184,7 @@ export class WorkerPool<
 		}
 		if (!this.onUpdate) return;
 		try {
-			this.onUpdate(this.getStats());
+			isolateAsyncFailure(this.onUpdate(this.getStats()));
 		} catch {
 			// Observers are isolated from scheduler control flow by design.
 		}
@@ -1180,7 +1192,7 @@ export class WorkerPool<
 
 	private _emit(event: WorkerPoolEvent): void {
 		try {
-			this.onEvent?.(event);
+			isolateAsyncFailure(this.onEvent?.(event));
 		} catch {
 			// Event observers are isolated from scheduler control flow by design.
 		}

--- a/packages/comlink-worker-pool/src/internal/lifecycle.ts
+++ b/packages/comlink-worker-pool/src/internal/lifecycle.ts
@@ -19,6 +19,16 @@ export interface WorkerMetadata<TProxy, TTask, TResult> {
 	failureEventTypes: string[];
 }
 
+/** Consumes a callback's optional thenable so asynchronous failures stay isolated. */
+export function isolateAsyncFailure(result: unknown): void {
+	if (
+		result !== null &&
+		(typeof result === "object" || typeof result === "function")
+	) {
+		void Promise.resolve(result).catch(() => {});
+	}
+}
+
 export function monotonicNow(): number {
 	return typeof globalThis.performance?.now === "function"
 		? globalThis.performance.now()

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,6 +9,7 @@
 		"dev": "vite",
 		"build": "vite build",
 		"preview": "vite preview",
+		"test": "bun test",
 		"lint": "biome check .",
 		"typecheck": "tsc --noEmit"
 	},

--- a/packages/playground/src/App.tsx
+++ b/packages/playground/src/App.tsx
@@ -83,6 +83,7 @@ function App() {
 		failed: 0,
 		status: "idle",
 	});
+	const batchGenerationRef = useRef(0);
 	const logSequence = useRef(0);
 	const logListRef = useRef<HTMLOListElement>(null);
 
@@ -145,6 +146,7 @@ function App() {
 		event.preventDefault();
 		const size = Math.max(1, Math.min(16, Math.round(draftSize)));
 		const concurrency = Math.max(1, Math.min(8, Math.round(draftConcurrency)));
+		++batchGenerationRef.current;
 		setDraftSize(size);
 		setDraftConcurrency(concurrency);
 		setStats(null);
@@ -174,6 +176,7 @@ function App() {
 
 	const runBatch = async () => {
 		if (!pool.api) return;
+		const generation = ++batchGenerationRef.current;
 		const taskTotal = Math.max(1, Math.min(40, Math.round(batchCount)));
 		const delayMs = Math.max(0, Math.min(5_000, Math.round(batchDelay)));
 		setBatchCount(taskTotal);
@@ -188,6 +191,7 @@ function App() {
 				Boolean(call),
 		);
 		const settled = await Promise.allSettled(calls);
+		if (batchGenerationRef.current !== generation) return;
 		const completed = settled.filter(
 			(result) => result.status === "fulfilled",
 		).length;
@@ -252,7 +256,11 @@ function App() {
 				<div className="summary-stat">
 					<span className="stat-label">Settled</span>
 					<strong>
-						{(stats?.completedTasks ?? 0) + (stats?.failedTasks ?? 0)}
+						{(stats?.completedTasks ?? 0) +
+							(stats?.failedTasks ?? 0) +
+							(stats?.cancelledTasks ?? 0) +
+							(stats?.timedOutTasks ?? 0) +
+							(stats?.droppedTasks ?? 0)}
 					</strong>
 				</div>
 			</section>

--- a/packages/playground/src/text-analysis.test.ts
+++ b/packages/playground/src/text-analysis.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { analyzeText } from "./text-analysis";
+
+describe("analyzeText", () => {
+	test("counts and reverses user-perceived characters", async () => {
+		await expect(analyzeText("A💩é")).resolves.toEqual({
+			characters: 3,
+			reversed: "é💩A",
+			words: 1,
+		});
+	});
+
+	test("keeps joined emoji graphemes intact", async () => {
+		const family = "👨‍👩‍👧‍👦";
+		await expect(analyzeText(family)).resolves.toEqual({
+			characters: 1,
+			reversed: family,
+			words: 1,
+		});
+	});
+});

--- a/packages/playground/src/text-analysis.ts
+++ b/packages/playground/src/text-analysis.ts
@@ -1,0 +1,19 @@
+export interface TextAnalysis {
+	characters: number;
+	reversed: string;
+	words: number;
+}
+
+/** Analyzes text using user-perceived grapheme clusters for character operations. */
+export async function analyzeText(text: string): Promise<TextAnalysis> {
+	if (typeof text !== "string") throw new Error("Text input must be a string");
+	const graphemes = Array.from(
+		new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text),
+		({ segment }) => segment,
+	);
+	return {
+		characters: graphemes.length,
+		reversed: graphemes.reverse().join(""),
+		words: text.trim().split(/\s+/).filter(Boolean).length,
+	};
+}

--- a/packages/playground/src/worker.ts
+++ b/packages/playground/src/worker.ts
@@ -1,4 +1,6 @@
 import * as Comlink from "comlink";
+import { analyzeText } from "./text-analysis";
+export { analyzeText, type TextAnalysis } from "./text-analysis";
 
 function fibonacci(n: number): number {
 	if (n <= 1) return n;
@@ -14,21 +16,6 @@ export async function fibAsync(n: number): Promise<number> {
 		throw new Error("Fibonacci input must be an integer from 0 to 45");
 	}
 	return fibonacci(n);
-}
-
-export interface TextAnalysis {
-	characters: number;
-	reversed: string;
-	words: number;
-}
-
-export async function analyzeText(text: string): Promise<TextAnalysis> {
-	if (typeof text !== "string") throw new Error("Text input must be a string");
-	return {
-		characters: text.length,
-		reversed: [...text].reverse().join(""),
-		words: text.trim().split(/\s+/).filter(Boolean).length,
-	};
 }
 
 export interface DelayedTaskResult {


### PR DESCRIPTION
## Summary

This fixes the lifecycle and concurrency bugs found during the full function audit:

- classify concurrent worker timeouts per task instead of sharing one timeout reason
- preserve proxy method receivers
- isolate asynchronous callback rejections
- prevent duplicate queue timers during reentrant events
- remove playground batch-state races and correct settled totals
- handle user-visible text by grapheme cluster instead of UTF-16 code unit

## Root causes

Several lifecycle decisions were stored or scheduled at worker scope even though they belonged to individual tasks. Proxy methods were also invoked detached from their owning object, callback protection only covered synchronous throws, and the playground allowed stale asynchronous completions to mutate newer runs.

## Impact

Worker failures and timeouts now settle the correct tasks, queue processing remains single-scheduled under reentrancy, proxied methods retain their expected receiver, callback failures cannot leak as unhandled rejections, and the playground reports stable, Unicode-correct results.

## Validation

- bun run test — 92 passed
- bun run lint
- bun run typecheck
- bun run build
- bun run playground:build
- bun run test:packages
- bun run benchmark:bundle
- bunx playwright test --project=chromium --project=firefox — 6 passed

WebKit was not run because the host is missing the required GTK/GStreamer libraries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added text analysis in the playground, including character, word, and reversed-text results that correctly handle emoji and combined characters.
  - Expanded “Settled” metrics to include completed, failed, cancelled, timed-out, and dropped tasks.

- **Bug Fixes**
  - Prevented outdated batch results from replacing newer playground results after configuration changes.
  - Improved worker-pool handling for timeouts, crashes, aborted tasks, and callback failures.

- **Tests**
  - Expanded coverage for lifecycle reliability, reentrant scheduling, and text analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->