### PR TITLE
Harden worker-pool lifecycle and cut spawn/dispatch overhead

### DIFF
--- a/.changeset/bright-workers-rest.md
+++ b/.changeset/bright-workers-rest.md
@@ -4,3 +4,5 @@
 ---
 
 Harden scheduler reentrancy, stalled drains, timeout enforcement, discarded thenable cleanup, task outcome accounting, React binding and async-observer isolation, commit-phase hook binding, callable state values, and interface-based API typings. Refresh vulnerable development dependencies without cross-major overrides, declare root browser/package-test and React type dependencies explicitly, migrate package builds to current Bunup configuration with isolated ESM and CommonJS outputs, remove stale build artifacts before build and watch modes, validate each emitted source map, and simplify repository configuration and tests.
+
+Prevent premature shutdown confirmation while worker construction is in progress, capture failures during proxy/listener setup, and ensure cancellation reentrancy cannot execute settled work. Replace quadratic queue operations with an adaptive FIFO/priority heap, add constant-time idle-worker and removal paths, reduce dispatch allocations, and enforce task-throughput, worker-churn, and burst-lifecycle performance budgets.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The performance harness can also be run directly:
 bun run benchmark
 ```
 
-Its runtime task count, sample count, and p95 budget can be changed with `WORKER_POOL_BENCHMARK_TASKS`, `WORKER_POOL_BENCHMARK_RUNS`, and `WORKER_POOL_BENCHMARK_BUDGET_MS`.
+The runtime harness measures task throughput, sequential worker churn, and burst creation/teardown. Configure task count, sample count, and task p95 with `WORKER_POOL_BENCHMARK_TASKS`, `WORKER_POOL_BENCHMARK_RUNS`, and `WORKER_POOL_BENCHMARK_BUDGET_MS`. Churn uses `WORKER_POOL_BENCHMARK_CHURN_WORKERS` and `WORKER_POOL_BENCHMARK_CHURN_BUDGET_MS`; burst lifecycle uses `WORKER_POOL_BENCHMARK_BURST_WORKERS` and `WORKER_POOL_BENCHMARK_BURST_BUDGET_MS`.
 
 ## Releases
 

--- a/packages/comlink-worker-pool/README.md
+++ b/packages/comlink-worker-pool/README.md
@@ -89,6 +89,8 @@ const closeReport = await pool.close(); // reject accepted work immediately
 
 Both methods reject future calls, terminate workers, and return a `WorkerPoolShutdownReport`. The shared `pool.terminated` promise exposes the same final report.
 
+Shutdown completion also waits for synchronous worker construction already in progress. If a factory or proxy setup reenters shutdown, every worker it returns is quarantined and included in the final report before `terminated` resolves.
+
 `terminateAll()` is the synchronous compatibility entry point. It begins immediate close and cleanup but does not await the final report.
 
 Worker termination is retried with bounded exponential backoff. A termination that cannot be confirmed is quarantined and remains visible in statistics. Replacement workers are limited by `terminationFailureWorkerBuffer`, preventing an unbounded number of potentially live workers.

--- a/packages/comlink-worker-pool/src/WorkerPool.reentrancy.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.reentrancy.test.ts
@@ -37,4 +37,42 @@ describe("WorkerPool - reentrant scheduling", () => {
 		expect(jest.getTimerCount()).toBe(0);
 		await pool.close();
 	});
+	test("does not execute a task aborted during listener registration", async () => {
+		let invocations = 0;
+		const signal = {
+			aborted: false,
+			reason: "synchronous registration abort",
+			addEventListener: (
+				_type: string,
+				listener: EventListenerOrEventListenerObject,
+			) => {
+				if (typeof listener === "function") listener(new Event("abort"));
+				else listener.handleEvent(new Event("abort"));
+			},
+			removeEventListener: () => {},
+		} as unknown as AbortSignal;
+		const pool = new WorkerPool<ReentrantApi>({
+			size: 1,
+			taskTimeoutMs: false,
+			workerFactory: () => new ReentrantWorker() as unknown as Worker,
+			proxyFactory: () => ({
+				run: async (value) => {
+					invocations++;
+					return value;
+				},
+			}),
+		});
+
+		await expect(
+			pool.run("run", ["cancelled"], { signal }),
+		).rejects.toMatchObject({ name: "WorkerTaskAbortedError" });
+		await Promise.resolve();
+		expect(invocations).toBe(0);
+		expect(pool.getStats()).toMatchObject({
+			cancelledTasks: 1,
+			startedTasks: 0,
+			workers: 0,
+		});
+		await pool.close();
+	});
 });

--- a/packages/comlink-worker-pool/src/WorkerPool.robustness.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.robustness.test.ts
@@ -24,9 +24,9 @@ class PartialListenerWorker extends ControlledWorker {
 		callback: EventListenerOrEventListenerObject | null,
 		options?: boolean | AddEventListenerOptions,
 	): void {
-		if (type === "messageerror") throw new Error("listener setup failed");
 		super.addEventListener(type, callback, options);
 		this.activeListenerTypes.add(type);
+		if (type === "messageerror") throw new Error("listener setup failed");
 	}
 
 	override removeEventListener(
@@ -355,6 +355,30 @@ describe("WorkerPool - lifecycle robustness", () => {
 		expect(worker.terminateCalls).toBe(1);
 		expect(pool.getStats()).toMatchObject({ workers: 0, queue: 0 });
 		pool.terminateAll();
+	});
+	test("captures worker failure during proxy construction", async () => {
+		const worker = new ControlledWorker();
+		let invocations = 0;
+		const pool = new WorkerPool({
+			size: 1,
+			workerFactory: () => asWorker(worker),
+			proxyFactory: (createdWorker) => {
+				createdWorker.dispatchEvent(new Event("error"));
+				return {
+					run: async () => {
+						invocations++;
+					},
+				};
+			},
+		});
+
+		await expect(pool.getApi().run()).rejects.toBeInstanceOf(
+			WorkerCrashedError,
+		);
+		expect(invocations).toBe(0);
+		expect(worker.terminateCalls).toBe(1);
+		expect(pool.getStats()).toMatchObject({ workers: 0, queue: 0 });
+		await pool.close();
 	});
 
 	test("termination reentered from worker construction cannot leak a worker", async () => {

--- a/packages/comlink-worker-pool/src/WorkerPool.shutdown.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.shutdown.test.ts
@@ -188,6 +188,30 @@ describe("WorkerPool - awaitable shutdown", () => {
 		});
 	});
 
+	test("terminateAll still completes when a managed worker index is corrupt", async () => {
+		const worker = new TestWorker();
+		const pool = new WorkerPool<TestApi>({
+			size: 1,
+			workerFactory: () => worker as unknown as Worker,
+			proxyFactory: () => ({ run: async (value) => value }),
+		});
+		await pool.run("run", ["create worker"]);
+		const internals = pool as unknown as {
+			workers: Array<{ managed: boolean; poolIndex: number }>;
+		};
+		expect(internals.workers).toHaveLength(1);
+		expect(internals.workers[0]?.managed).toBe(true);
+		internals.workers[0].poolIndex = -1;
+
+		await expect(pool.close()).resolves.toEqual({
+			confirmed: true,
+			unconfirmedWorkers: 0,
+			terminationFailures: 0,
+		});
+		expect(worker.terminateCalls).toBe(1);
+		expect(internals.workers).toHaveLength(0);
+	});
+
 	test("reports exhausted termination attempts without hanging", async () => {
 		const worker = new TestWorker();
 		const pool = new WorkerPool<TestApi>({

--- a/packages/comlink-worker-pool/src/WorkerPool.shutdown.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.shutdown.test.ts
@@ -150,6 +150,44 @@ describe("WorkerPool - awaitable shutdown", () => {
 		expect(pool.terminated).toBe(closed);
 	});
 
+	test("waits for a worker created during reentrant shutdown", async () => {
+		const worker = new TestWorker();
+		const termination = deferred<void>();
+		const holder: { pool?: WorkerPool<TestApi> } = {};
+		const pool = new WorkerPool<TestApi>({
+			size: 1,
+			terminationRetryAttempts: 0,
+			workerFactory: () => {
+				holder.pool?.terminateAll();
+				return worker as unknown as Worker;
+			},
+			proxyFactory: () => ({ run: async (value) => value }),
+			workerTerminator: () => termination.promise,
+		});
+		holder.pool = pool;
+		let report: WorkerPoolShutdownReport | undefined;
+		void pool.terminated.then((value) => {
+			report = value;
+		});
+
+		await expect(pool.run("run", ["closed"])).rejects.toBeInstanceOf(
+			WorkerPoolTerminatedError,
+		);
+		await flush();
+		expect(report).toBeUndefined();
+		expect(pool.getStats()).toMatchObject({
+			healthyWorkers: 0,
+			quarantinedWorkers: 1,
+		});
+
+		termination.resolve();
+		await expect(pool.terminated).resolves.toEqual({
+			confirmed: true,
+			unconfirmedWorkers: 0,
+			terminationFailures: 0,
+		});
+	});
+
 	test("reports exhausted termination attempts without hanging", async () => {
 		const worker = new TestWorker();
 		const pool = new WorkerPool<TestApi>({

--- a/packages/comlink-worker-pool/src/WorkerPool.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.ts
@@ -29,6 +29,8 @@ import {
 	TerminationController,
 } from "./internal/termination";
 
+const WORKER_FAILURE_EVENT_TYPES = ["error", "messageerror", "close"] as const;
+
 export * from "./errors";
 
 /** Factory for creating a new Web Worker. */
@@ -278,11 +280,15 @@ export class WorkerPool<
 
 	private workers: WorkerMetadata<TProxy, TTask, TResult>[] = [];
 	private readonly queue = new SchedulerQueue<TTask, TResult>();
+	private readonly idleWorkers = new Set<
+		WorkerMetadata<TProxy, TTask, TResult>
+	>();
 	private nextWorkerId = 0;
 	private nextTaskSequence = 0;
 	private accepting = true;
 	private drainRequested = false;
 	private terminationStarted = false;
+	private workerCreationsInProgress = 0;
 	private scheduling = false;
 	private rescheduleRequested = false;
 	private shutdownResolved = false;
@@ -407,13 +413,15 @@ export class WorkerPool<
 				DEFAULT_TERMINATION_ATTEMPT_TIMEOUT_MS,
 			workerTerminator: options.workerTerminator,
 			onFailure: (error) => {
-				this._emit({
-					type: "worker-termination-failed",
-					timestamp: Date.now(),
-					workerId: error.workerId,
-					attempt: error.attempt,
-					exhausted: error.exhausted,
-				});
+				if (this.onEvent) {
+					this._emit({
+						type: "worker-termination-failed",
+						timestamp: Date.now(),
+						workerId: error.workerId,
+						attempt: error.attempt,
+						exhausted: error.exhausted,
+					});
+				}
 				try {
 					isolateAsyncFailure(options.onWorkerTerminationError?.(error));
 				} catch {
@@ -430,12 +438,18 @@ export class WorkerPool<
 
 	/** Returns a proxy API that schedules method calls on this pool. */
 	public getApi(): TProxy {
+		let cachedMethodName: string | undefined;
+		let cachedMethod: ((...args: unknown[]) => Promise<TResult>) | undefined;
 		const handler: ProxyHandler<object> = {
 			get: (_target, prop) => {
 				// Prevent Promise/React thenable assimilation of the API proxy.
 				if (prop === "then" || typeof prop !== "string") return undefined;
-				return (...args: unknown[]) =>
-					this._run({ method: prop, args } as TTask);
+				if (prop !== cachedMethodName || cachedMethod === undefined) {
+					cachedMethodName = prop;
+					cachedMethod = (...args: unknown[]) =>
+						this._run({ method: prop, args } as TTask);
+				}
+				return cachedMethod;
 			},
 		};
 		return new Proxy(Object.create(null), handler) as TProxy;
@@ -461,7 +475,8 @@ export class WorkerPool<
 		if (
 			this.queue.length > 0 &&
 			this.workers.length === 0 &&
-			this.termination.count === 0
+			this.termination.count === 0 &&
+			this.workerCreationsInProgress === 0
 		) {
 			// A bounded no-progress scheduling pass has no future trigger once the
 			// pool stops accepting submissions. Close rather than leaving drain()
@@ -490,13 +505,14 @@ export class WorkerPool<
 		for (const item of this.queue.drain()) {
 			this._settleTask(item, false, reason, "pool-closed");
 		}
-		for (const worker of [...this.workers]) {
-			for (const item of [...worker.activeTasks]) {
+		while (this.workers.length > 0) {
+			const worker = this.workers[this.workers.length - 1];
+			for (const item of worker.activeTasks) {
 				worker.activeTasks.delete(item);
 				this._settleTask(item, false, reason, "pool-closed");
 			}
-			worker.activeTasks.clear();
-			this._removeWorker(worker, true, "shutdown");
+			if (worker.managed) this._removeWorker(worker, true, "shutdown");
+			else this.workers.pop();
 		}
 		this._updateStats();
 	}
@@ -505,16 +521,23 @@ export class WorkerPool<
 	public getStats(): WorkerPoolStats {
 		const now = monotonicNow();
 		const oldestQueuedAt = this.queue.oldestEnqueuedAt();
-		const runningTasks = this.workers.reduce(
-			(sum, worker) => sum + worker.activeTasks.size,
-			0,
-		);
-		const availableForConcurrency = this.workers.filter(
-			(worker) =>
+		let runningTasks = 0;
+		let idleWorkers = 0;
+		let availableForConcurrency = 0;
+		for (const worker of this.workers) {
+			const activeTasks = worker.activeTasks.size;
+			runningTasks += activeTasks;
+			if (activeTasks === 0) idleWorkers++;
+			if (
 				!worker.markedForTermination &&
-				worker.activeTasks.size < this.maxConcurrentTasksPerWorker &&
-				!this._hasExpired(worker),
-		).length;
+				activeTasks < this.maxConcurrentTasksPerWorker &&
+				(this.maxWorkerLifetimeMs === undefined ||
+					now - worker.createdAt < this.maxWorkerLifetimeMs)
+			) {
+				availableForConcurrency++;
+			}
+		}
+
 		const physicalWorkerCount = this.workers.length + this.termination.count;
 		const uncreatedCapacity = this.terminationStarted
 			? 0
@@ -549,9 +572,7 @@ export class WorkerPool<
 			quarantinedWorkers: this.termination.count,
 			terminationFailureWorkerBuffer: this.terminationFailureWorkerBuffer,
 			terminationFailures: this.termination.failures,
-			idleWorkers: this.workers.filter(
-				(worker) => worker.activeTasks.size === 0,
-			).length,
+			idleWorkers,
 			runningTasks,
 			availableForConcurrency,
 			submittedTasks: this.submittedTasks,
@@ -602,35 +623,40 @@ export class WorkerPool<
 				sequence: this.nextTaskSequence++,
 				enqueuedAt,
 				signal: options.signal,
+				queueIndex: -1,
+				previousQueued: null,
+				nextQueued: null,
 			};
 			this.submittedTasks++;
 			if (item.signal) {
 				item.abortHandler = () => this._abortTask(item);
-				item.signal.addEventListener("abort", item.abortHandler, {
-					once: true,
-				});
-				if (item.signal.aborted) {
-					this._abortTask(item);
+				try {
+					item.signal.addEventListener("abort", item.abortHandler, {
+						once: true,
+					});
+					if (item.signal.aborted) this._abortTask(item);
+				} catch (error) {
+					this._settleTask(item, false, error);
+					this._updateStats();
 					return;
 				}
+				if (item.settled) return;
 			}
-			this._insertQueuedTask(item);
-			this._emit({
-				type: "task-queued",
-				timestamp: Date.now(),
-				taskId: item.sequence,
-				method: String(item.task.method),
-				priority: item.priority,
-			});
+			this.queue.insert(item);
+			if (this.onEvent) {
+				this._emit({
+					type: "task-queued",
+					timestamp: Date.now(),
+					taskId: item.sequence,
+					method: String(item.task.method),
+					priority: item.priority,
+				});
+			}
 			this._startQueueTimer(item, queueTimeoutMs);
 			this._next();
 			this._enforceQueueLimit(item);
 			this._updateStats();
 		});
-	}
-
-	private _insertQueuedTask(item: ScheduledTask<TTask, TResult>): void {
-		this.queue.insert(item);
 	}
 
 	private _enforceQueueLimit(submitted: ScheduledTask<TTask, TResult>): void {
@@ -651,9 +677,7 @@ export class WorkerPool<
 	private _abortTask(item: ScheduledTask<TTask, TResult>): void {
 		if (item.settled) return;
 		this.queue.remove(item);
-		const isRunning = this.workers.some((worker) =>
-			worker.activeTasks.has(item),
-		);
+		const isRunning = item.startedAt !== undefined;
 		this._settleTask(
 			item,
 			false,
@@ -758,18 +782,79 @@ export class WorkerPool<
 	}
 
 	private _getAvailableWorker(): WorkerMetadata<TProxy, TTask, TResult> | null {
-		let leastLoaded: WorkerMetadata<TProxy, TTask, TResult> | null = null;
-		for (const worker of [...this.workers]) {
+		for (const worker of this.idleWorkers) {
+			if (
+				!worker.managed ||
+				worker.markedForTermination ||
+				worker.activeTasks.size !== 0
+			) {
+				this.idleWorkers.delete(worker);
+				continue;
+			}
 			if (this._hasExpired(worker)) {
 				worker.markedForTermination = true;
 				worker.retirementReason = "lifetime";
-				if (worker.activeTasks.size === 0) {
-					this._removeWorker(worker, false, "lifetime");
-				}
+				this._removeWorker(worker, false, "lifetime");
+				continue;
+			}
+			return worker;
+		}
+
+		const physicalWorkerCount = this.workers.length + this.termination.count;
+		const canCreate =
+			this.workers.length < this.size &&
+			physicalWorkerCount < this.physicalWorkerLimit;
+		if (!canCreate) return this._findLeastLoadedWorker();
+
+		this.workerCreationsInProgress++;
+		try {
+			let worker: WorkerMetadata<TProxy, TTask, TResult>;
+			try {
+				worker = this._createWorker();
+			} catch (error) {
+				const fallback = this._findLeastLoadedWorker();
+				if (fallback) return fallback;
+				throw error;
+			}
+			worker.poolIndex = this.workers.length;
+			this.workers.push(worker);
+			worker.managed = true;
+			if (this.onEvent) {
+				this._emit({
+					type: "worker-created",
+					timestamp: Date.now(),
+					workerId: worker.id,
+				});
+			}
+			if (!this._containsWorker(worker)) return null;
+			if (this.terminationStarted) {
+				this._removeWorker(worker, true, "shutdown");
+				return null;
+			}
+			this._startLifetimeTimer(worker);
+			if (!this._containsWorker(worker)) return null;
+			this._startIdleTimer(worker);
+			return worker;
+		} finally {
+			this.workerCreationsInProgress--;
+			if (this.terminationStarted || this.drainRequested) this._updateStats();
+		}
+	}
+
+	private _findLeastLoadedWorker(): WorkerMetadata<
+		TProxy,
+		TTask,
+		TResult
+	> | null {
+		let leastLoaded: WorkerMetadata<TProxy, TTask, TResult> | null = null;
+		for (const worker of this.workers) {
+			if (!worker.managed || worker.markedForTermination) continue;
+			if (this._hasExpired(worker)) {
+				worker.markedForTermination = true;
+				worker.retirementReason = "lifetime";
 				continue;
 			}
 			if (
-				!worker.markedForTermination &&
 				worker.activeTasks.size < this.maxConcurrentTasksPerWorker &&
 				(leastLoaded === null ||
 					worker.activeTasks.size < leastLoaded.activeTasks.size)
@@ -777,44 +862,7 @@ export class WorkerPool<
 				leastLoaded = worker;
 			}
 		}
-
-		const physicalWorkerCount = this.workers.length + this.termination.count;
-		const canCreate =
-			this.workers.length < this.size &&
-			physicalWorkerCount < this.physicalWorkerLimit;
-		if (!canCreate || leastLoaded?.activeTasks.size === 0) {
-			return leastLoaded;
-		}
-
-		let worker: WorkerMetadata<TProxy, TTask, TResult>;
-		try {
-			worker = this._createWorker();
-		} catch (error) {
-			if (
-				leastLoaded &&
-				this._containsWorker(leastLoaded) &&
-				!leastLoaded.markedForTermination &&
-				leastLoaded.activeTasks.size < this.maxConcurrentTasksPerWorker
-			) {
-				return leastLoaded;
-			}
-			throw error;
-		}
-		this.workers.push(worker);
-		this._emit({
-			type: "worker-created",
-			timestamp: Date.now(),
-			workerId: worker.id,
-		});
-		if (!this._containsWorker(worker)) return null;
-		if (this.terminationStarted) {
-			this._removeWorker(worker, true, "shutdown");
-			return null;
-		}
-		this._startLifetimeTimer(worker);
-		if (!this._containsWorker(worker)) return null;
-		this._startIdleTimer(worker);
-		return worker;
+		return leastLoaded;
 	}
 
 	private _createWorker(): WorkerMetadata<TProxy, TTask, TResult> {
@@ -830,57 +878,65 @@ export class WorkerPool<
 		}
 		this.knownWorkers.add(worker);
 
-		let proxy: TProxy;
+		const id = this.nextWorkerId++;
+		const failureEventTypes: string[] = [];
+		// biome-ignore lint/style/useConst: listener setup must close over metadata before assignment.
+		let metadata: WorkerMetadata<TProxy, TTask, TResult> | undefined;
+		let constructionFailure: WorkerCrashedError | undefined;
+		const failureHandler = (event: Event) => {
+			const cause =
+				typeof ErrorEvent !== "undefined" &&
+				event instanceof ErrorEvent &&
+				event.error !== undefined
+					? event.error
+					: event;
+			const reason = new WorkerCrashedError(id, cause);
+			if (metadata?.managed) {
+				this._handleWorkerFailure(metadata, reason);
+			} else {
+				constructionFailure ??= reason;
+			}
+		};
+
+		let proxy: TProxy | undefined;
 		try {
-			proxy = this.proxyFactory(worker);
+			for (const type of WORKER_FAILURE_EVENT_TYPES) {
+				failureEventTypes.push(type);
+				worker.addEventListener(type, failureHandler);
+				if (constructionFailure) throw constructionFailure;
+			}
+
+			const createdProxy = this.proxyFactory(worker);
 			if (
-				(typeof proxy !== "object" && typeof proxy !== "function") ||
-				!proxy
+				(typeof createdProxy !== "object" &&
+					typeof createdProxy !== "function") ||
+				!createdProxy
 			) {
 				throw new TypeError("proxyFactory must return a proxy object");
 			}
+			proxy = createdProxy;
+			if (constructionFailure) throw constructionFailure;
 		} catch (error) {
-			const termination = this.termination.quarantine(worker);
+			this._removeFailureListeners(worker, failureHandler, failureEventTypes);
+			if (proxy !== undefined) this._cleanupProxy(proxy);
+			const termination = this.termination.quarantine(worker, id);
 			this.termination.attempt(termination);
-			throw error;
+			throw constructionFailure ?? error;
 		}
 
-		const id = this.nextWorkerId++;
-		const metadata = {
+		metadata = {
 			id,
 			proxy,
 			worker,
 			taskCount: 0,
 			createdAt: monotonicNow(),
 			activeTasks: new Set<ScheduledTask<TTask, TResult>>(),
+			poolIndex: -1,
 			markedForTermination: false,
-			failureHandler: (event: Event) => {
-				const cause =
-					typeof ErrorEvent !== "undefined" &&
-					event instanceof ErrorEvent &&
-					event.error !== undefined
-						? event.error
-						: event;
-				this._handleWorkerFailure(
-					metadata,
-					new WorkerCrashedError(metadata.id, cause),
-				);
-			},
-			failureEventTypes: [] as string[],
-		} satisfies WorkerMetadata<TProxy, TTask, TResult>;
-
-		try {
-			for (const type of ["error", "messageerror", "close"]) {
-				worker.addEventListener(type, metadata.failureHandler);
-				metadata.failureEventTypes.push(type);
-			}
-		} catch (error) {
-			const termination = this.termination.quarantine(worker, id);
-			this._removeFailureListeners(metadata);
-			this._cleanupProxy(proxy);
-			this.termination.attempt(termination);
-			throw error;
-		}
+			managed: false,
+			failureHandler,
+			failureEventTypes,
+		};
 		return metadata;
 	}
 
@@ -888,6 +944,7 @@ export class WorkerPool<
 		worker: WorkerMetadata<TProxy, TTask, TResult>,
 		item: ScheduledTask<TTask, TResult>,
 	): void {
+		if (item.settled) return;
 		if (this._expireQueuedTaskIfNeeded(item)) return;
 		if (item.queueTimeout !== undefined) clearTimeout(item.queueTimeout);
 		item.queueTimeout = undefined;
@@ -910,14 +967,14 @@ export class WorkerPool<
 			this._startTaskTimer(worker, item);
 		}
 
-		void Promise.resolve()
-			.then(() => {
+		queueMicrotask(() => {
+			try {
 				if (
 					!this._containsWorker(worker) ||
 					!worker.activeTasks.has(item) ||
 					this._expireTaskIfNeeded(worker, item)
 				) {
-					return undefined;
+					return;
 				}
 				const method = worker.proxy[item.task.method];
 				if (
@@ -925,7 +982,7 @@ export class WorkerPool<
 					!worker.activeTasks.has(item) ||
 					this._expireTaskIfNeeded(worker, item)
 				) {
-					return undefined;
+					return;
 				}
 				if (typeof method !== "function") {
 					throw new TypeError(
@@ -939,22 +996,26 @@ export class WorkerPool<
 					this._expireTaskIfNeeded(worker, item)
 				) {
 					isolateAsyncFailure(result);
-					return undefined;
+					return;
 				}
-				return result;
-			})
-			.then(
-				(result) => this._completeTask(worker, item, true, result as TResult),
-				(error) => this._completeTask(worker, item, false, error),
-			);
-		this._emit({
-			type: "task-started",
-			timestamp: Date.now(),
-			taskId: item.sequence,
-			method: String(item.task.method),
-			workerId: worker.id,
-			queueWaitMs: Math.max(0, item.startedAt - item.enqueuedAt),
+				void Promise.resolve(result).then(
+					(value) => this._completeTask(worker, item, true, value as TResult),
+					(error) => this._completeTask(worker, item, false, error),
+				);
+			} catch (error) {
+				this._completeTask(worker, item, false, error);
+			}
 		});
+		if (this.onEvent) {
+			this._emit({
+				type: "task-started",
+				timestamp: Date.now(),
+				taskId: item.sequence,
+				method: String(item.task.method),
+				workerId: worker.id,
+				queueWaitMs: Math.max(0, item.startedAt - item.enqueuedAt),
+			});
+		}
 	}
 
 	private _completeTask(
@@ -991,7 +1052,7 @@ export class WorkerPool<
 	): void {
 		if (!this._containsWorker(worker)) return;
 		worker.markedForTermination = true;
-		for (const item of [...worker.activeTasks]) {
+		for (const item of worker.activeTasks) {
 			worker.activeTasks.delete(item);
 			const taskReason =
 				triggeringTask !== undefined && item !== triggeringTask
@@ -1031,8 +1092,13 @@ export class WorkerPool<
 			item.timeout = undefined;
 		}
 		if (item.abortHandler && item.signal) {
-			item.signal.removeEventListener("abort", item.abortHandler);
+			const abortHandler = item.abortHandler;
 			item.abortHandler = undefined;
+			try {
+				item.signal.removeEventListener("abort", abortHandler);
+			} catch {
+				// A malformed signal must not interrupt task settlement.
+			}
 		}
 		if (item.settled) return;
 		item.settled = true;
@@ -1055,18 +1121,20 @@ export class WorkerPool<
 		}
 		if (succeeded) item.resolve(value as TResult);
 		else item.reject(value);
-		this._emit({
-			type: "task-settled",
-			timestamp: Date.now(),
-			taskId: item.sequence,
-			method: String(item.task.method),
-			workerId: item.workerId,
-			outcome,
-			durationMs: Math.max(
-				0,
-				monotonicNow() - (item.startedAt ?? item.enqueuedAt),
-			),
-		});
+		if (this.onEvent) {
+			this._emit({
+				type: "task-settled",
+				timestamp: Date.now(),
+				taskId: item.sequence,
+				method: String(item.task.method),
+				workerId: item.workerId,
+				outcome,
+				durationMs: Math.max(
+					0,
+					monotonicNow() - (item.startedAt ?? item.enqueuedAt),
+				),
+			});
+		}
 	}
 
 	private _expireTaskIfNeeded(
@@ -1151,8 +1219,9 @@ export class WorkerPool<
 	private _startIdleTimer(
 		worker: WorkerMetadata<TProxy, TTask, TResult>,
 	): void {
-		if (this.workerIdleTimeoutMs === undefined) return;
 		this._clearIdleTimer(worker);
+		this.idleWorkers.add(worker);
+		if (this.workerIdleTimeoutMs === undefined) return;
 		worker.idleDeadline = monotonicNow() + this.workerIdleTimeoutMs;
 
 		const schedule = () => {
@@ -1186,6 +1255,7 @@ export class WorkerPool<
 	private _clearIdleTimer(
 		worker: WorkerMetadata<TProxy, TTask, TResult>,
 	): void {
+		this.idleWorkers.delete(worker);
 		if (worker.idleTimer !== undefined) clearTimeout(worker.idleTimer);
 		worker.idleTimer = undefined;
 		worker.idleDeadline = undefined;
@@ -1196,37 +1266,52 @@ export class WorkerPool<
 		force: boolean,
 		reason: WorkerPoolWorkerRemovalReason,
 	): void {
-		const index = this.workers.findIndex((candidate) => candidate === worker);
-		if (index === -1 || (!force && worker.activeTasks.size > 0)) return;
+		if (!worker.managed || (!force && worker.activeTasks.size > 0)) return;
+		const index = worker.poolIndex;
+		if (index < 0 || this.workers[index] !== worker) return;
 
-		this.workers.splice(index, 1);
+		const last = this.workers.pop() as WorkerMetadata<TProxy, TTask, TResult>;
+		if (last !== worker) {
+			this.workers[index] = last;
+			last.poolIndex = index;
+		}
+		worker.poolIndex = -1;
+		worker.managed = false;
 		const termination = this.termination.quarantine(worker.worker, worker.id);
 		this._clearIdleTimer(worker);
 		if (worker.lifetimeTimer !== undefined) clearTimeout(worker.lifetimeTimer);
 		worker.lifetimeTimer = undefined;
-		this._removeFailureListeners(worker);
+		this._removeFailureListeners(
+			worker.worker,
+			worker.failureHandler,
+			worker.failureEventTypes,
+		);
 		this._cleanupProxy(worker.proxy);
-		this._emit({
-			type: "worker-removed",
-			timestamp: Date.now(),
-			workerId: worker.id,
-			reason,
-		});
+		if (this.onEvent) {
+			this._emit({
+				type: "worker-removed",
+				timestamp: Date.now(),
+				workerId: worker.id,
+				reason,
+			});
+		}
 		this.termination.attempt(termination);
 	}
 
 	private _containsWorker(
 		worker: WorkerMetadata<TProxy, TTask, TResult>,
 	): boolean {
-		return this.workers.some((candidate) => candidate === worker);
+		return worker.managed;
 	}
 
 	private _removeFailureListeners(
-		worker: WorkerMetadata<TProxy, TTask, TResult>,
+		worker: Worker,
+		failureHandler: (event: Event) => void,
+		failureEventTypes: string[],
 	): void {
-		for (const type of worker.failureEventTypes.splice(0)) {
+		for (const type of failureEventTypes.splice(0)) {
 			try {
-				worker.worker.removeEventListener(type, worker.failureHandler);
+				worker.removeEventListener(type, failureHandler);
 			} catch {
 				// Continue removing the remaining listeners independently.
 			}
@@ -1272,6 +1357,7 @@ export class WorkerPool<
 		if (
 			this.drainRequested &&
 			!this.terminationStarted &&
+			this.workerCreationsInProgress === 0 &&
 			this.queue.length === 0 &&
 			this.workers.every((worker) => worker.activeTasks.size === 0)
 		) {
@@ -1281,6 +1367,7 @@ export class WorkerPool<
 		if (
 			this.terminationStarted &&
 			!this.shutdownResolved &&
+			this.workerCreationsInProgress === 0 &&
 			this.workers.length === 0 &&
 			this.termination.allExhausted()
 		) {

--- a/packages/comlink-worker-pool/src/WorkerPool.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.ts
@@ -438,18 +438,21 @@ export class WorkerPool<
 
 	/** Returns a proxy API that schedules method calls on this pool. */
 	public getApi(): TProxy {
-		let cachedMethodName: string | undefined;
-		let cachedMethod: ((...args: unknown[]) => Promise<TResult>) | undefined;
+		const methodCache = new Map<
+			string,
+			(...args: unknown[]) => Promise<TResult>
+		>();
 		const handler: ProxyHandler<object> = {
 			get: (_target, prop) => {
 				// Prevent Promise/React thenable assimilation of the API proxy.
 				if (prop === "then" || typeof prop !== "string") return undefined;
-				if (prop !== cachedMethodName || cachedMethod === undefined) {
-					cachedMethodName = prop;
-					cachedMethod = (...args: unknown[]) =>
+				let cached = methodCache.get(prop);
+				if (cached === undefined) {
+					cached = (...args: unknown[]) =>
 						this._run({ method: prop, args } as TTask);
+					methodCache.set(prop, cached);
 				}
-				return cachedMethod;
+				return cached;
 			},
 		};
 		return new Proxy(Object.create(null), handler) as TProxy;

--- a/packages/comlink-worker-pool/src/WorkerPool.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.ts
@@ -509,13 +509,14 @@ export class WorkerPool<
 			this._settleTask(item, false, reason, "pool-closed");
 		}
 		while (this.workers.length > 0) {
+			const before = this.workers.length;
 			const worker = this.workers[this.workers.length - 1];
 			for (const item of worker.activeTasks) {
 				worker.activeTasks.delete(item);
 				this._settleTask(item, false, reason, "pool-closed");
 			}
 			if (worker.managed) this._removeWorker(worker, true, "shutdown");
-			else this.workers.pop();
+			if (this.workers.length === before) this.workers.pop();
 		}
 		this._updateStats();
 	}
@@ -1270,8 +1271,13 @@ export class WorkerPool<
 		reason: WorkerPoolWorkerRemovalReason,
 	): void {
 		if (!worker.managed || (!force && worker.activeTasks.size > 0)) return;
-		const index = worker.poolIndex;
-		if (index < 0 || this.workers[index] !== worker) return;
+		let index = worker.poolIndex;
+		if (index < 0 || this.workers[index] !== worker) {
+			// Shutdown must still detach and terminate even if poolIndex drifted.
+			if (!force) return;
+			index = this.workers.lastIndexOf(worker);
+			if (index < 0) return;
+		}
 
 		const last = this.workers.pop() as WorkerMetadata<TProxy, TTask, TResult>;
 		if (last !== worker) {

--- a/packages/comlink-worker-pool/src/internal/lifecycle.ts
+++ b/packages/comlink-worker-pool/src/internal/lifecycle.ts
@@ -11,6 +11,8 @@ export interface WorkerMetadata<TProxy, TTask, TResult> {
 	createdAt: number;
 	activeTasks: Set<ScheduledTask<TTask, TResult>>;
 	markedForTermination: boolean;
+	managed: boolean;
+	poolIndex: number;
 	retirementReason?: "lifetime" | "max-tasks";
 	idleTimer?: ReturnType<typeof setTimeout>;
 	idleDeadline?: number;

--- a/packages/comlink-worker-pool/src/internal/scheduler.ts
+++ b/packages/comlink-worker-pool/src/internal/scheduler.ts
@@ -24,7 +24,18 @@ export interface QueueEviction<TTask, TResult> {
 
 const FIFO_QUEUE_INDEX = -2;
 
-/** Priority/FIFO queue with bounded-overflow mechanics kept outside the pool. */
+/**
+ * Priority/FIFO queue with bounded-overflow mechanics kept outside the pool.
+ *
+ * Dual representation invariants:
+ * - The linked list (`oldest`/`newest`) is authoritative in both FIFO and heap
+ *   modes for enqueue order, drain order, oldest-age tracking, and overflow.
+ * - `items` is empty whenever `heapMode === false`. `promoteToHeap()` therefore
+ *   pushes into an empty array, and `contains()` can gate its FIFO branch on
+ *   `!heapMode` without consulting the heap.
+ * - In heap mode, `queueIndex` mirrors membership in `items`; FIFO mode uses
+ *   `FIFO_QUEUE_INDEX` so `remove`/`drain` can unlink without heap bookkeeping.
+ */
 export class SchedulerQueue<TTask, TResult> {
 	private readonly items: ScheduledTask<TTask, TResult>[] = [];
 	private oldest: ScheduledTask<TTask, TResult> | null = null;

--- a/packages/comlink-worker-pool/src/internal/scheduler.ts
+++ b/packages/comlink-worker-pool/src/internal/scheduler.ts
@@ -12,6 +12,9 @@ export interface ScheduledTask<TTask, TResult> extends Task<TTask, TResult> {
 	queueTimeout?: ReturnType<typeof setTimeout>;
 	queueDeadline?: number;
 	timeout?: ReturnType<typeof setTimeout>;
+	queueIndex: number;
+	previousQueued: ScheduledTask<TTask, TResult> | null;
+	nextQueued: ScheduledTask<TTask, TResult> | null;
 }
 
 export interface QueueEviction<TTask, TResult> {
@@ -19,52 +22,132 @@ export interface QueueEviction<TTask, TResult> {
 	dropped: boolean;
 }
 
+const FIFO_QUEUE_INDEX = -2;
+
 /** Priority/FIFO queue with bounded-overflow mechanics kept outside the pool. */
 export class SchedulerQueue<TTask, TResult> {
 	private readonly items: ScheduledTask<TTask, TResult>[] = [];
-	private readonly queued = new Set<ScheduledTask<TTask, TResult>>();
+	private oldest: ScheduledTask<TTask, TResult> | null = null;
+	private newest: ScheduledTask<TTask, TResult> | null = null;
+	private queueSize = 0;
+	private uniformPriority: number | undefined;
+	private heapMode = false;
 
 	get length(): number {
-		return this.items.length;
+		return this.queueSize;
 	}
 
 	insert(task: ScheduledTask<TTask, TResult>): void {
-		const index = this.items.findIndex(
-			(candidate) => candidate.priority < task.priority,
-		);
-		if (index === -1) this.items.push(task);
-		else this.items.splice(index, 0, task);
-		this.queued.add(task);
+		if (task.queueIndex !== -1) {
+			throw new Error("Scheduled task is already queued");
+		}
+
+		const previous = this.newest;
+		task.previousQueued = previous;
+		task.nextQueued = null;
+		if (previous) previous.nextQueued = task;
+		else this.oldest = task;
+		this.newest = task;
+		this.queueSize++;
+
+		if (!this.heapMode) {
+			if (this.queueSize === 1) this.uniformPriority = task.priority;
+			if (task.priority === this.uniformPriority) {
+				task.queueIndex = FIFO_QUEUE_INDEX;
+				return;
+			}
+			this.promoteToHeap();
+			return;
+		}
+
+		task.queueIndex = this.items.length;
+		this.items.push(task);
+		this.siftUp(task.queueIndex);
 	}
 
 	shift(): ScheduledTask<TTask, TResult> | undefined {
-		const task = this.items.shift();
-		if (task) this.queued.delete(task);
+		const task = this.heapMode ? this.items[0] : (this.oldest ?? undefined);
+		if (task) this.remove(task);
 		return task;
 	}
 
 	contains(task: ScheduledTask<TTask, TResult>): boolean {
-		return this.queued.has(task);
+		if (task.queueIndex === FIFO_QUEUE_INDEX) {
+			return (
+				!this.heapMode &&
+				(task.previousQueued !== null ||
+					task.nextQueued !== null ||
+					this.oldest === task)
+			);
+		}
+		return task.queueIndex >= 0 && this.items[task.queueIndex] === task;
 	}
 
 	remove(task: ScheduledTask<TTask, TResult>): boolean {
-		if (!this.queued.has(task)) return false;
-		const index = this.items.indexOf(task);
-		if (index === -1) return false;
-		this.items.splice(index, 1);
-		this.queued.delete(task);
+		if (!this.contains(task)) return false;
+
+		if (this.heapMode) {
+			const index = task.queueIndex;
+			const last = this.items.pop() as ScheduledTask<TTask, TResult>;
+			if (index < this.items.length) {
+				this.items[index] = last;
+				last.queueIndex = index;
+				const parentIndex = (index - 1) >> 1;
+				const parent = this.items[parentIndex];
+				if (
+					index > 0 &&
+					(last.priority > parent.priority ||
+						(last.priority === parent.priority &&
+							last.sequence < parent.sequence))
+				) {
+					this.siftUp(index);
+				} else {
+					this.siftDown(index);
+				}
+			}
+		}
+
+		const previous = task.previousQueued;
+		const next = task.nextQueued;
+		if (previous) previous.nextQueued = next;
+		else this.oldest = next;
+		if (next) next.previousQueued = previous;
+		else this.newest = previous;
+		task.queueIndex = -1;
+		task.previousQueued = null;
+		task.nextQueued = null;
+		this.queueSize--;
+		if (this.queueSize === 0) {
+			this.items.length = 0;
+			this.uniformPriority = undefined;
+			this.heapMode = false;
+		}
 		return true;
 	}
 
 	drain(): ScheduledTask<TTask, TResult>[] {
-		const tasks = this.items.splice(0);
-		this.queued.clear();
+		const tasks = new Array<ScheduledTask<TTask, TResult>>(this.queueSize);
+		let current = this.oldest;
+		let index = 0;
+		while (current) {
+			const next = current.nextQueued;
+			current.queueIndex = -1;
+			current.previousQueued = null;
+			current.nextQueued = null;
+			tasks[index++] = current;
+			current = next;
+		}
+		this.items.length = 0;
+		this.oldest = null;
+		this.newest = null;
+		this.queueSize = 0;
+		this.uniformPriority = undefined;
+		this.heapMode = false;
 		return tasks;
 	}
 
 	oldestEnqueuedAt(): number | null {
-		const oldest = this.queued.values().next().value;
-		return oldest?.enqueuedAt ?? null;
+		return this.oldest?.enqueuedAt ?? null;
 	}
 
 	enforceLimit(
@@ -73,18 +156,82 @@ export class SchedulerQueue<TTask, TResult> {
 		policy: QueueOverflowPolicy,
 	): QueueEviction<TTask, TResult>[] {
 		const evictions: QueueEviction<TTask, TResult>[] = [];
-		while (this.items.length > maxQueueSize) {
+		while (this.queueSize > maxQueueSize) {
 			let rejected = submitted;
 			let dropped = false;
 			if (!this.contains(submitted) || policy === "drop-oldest") {
-				rejected = this.items.reduce((oldest, candidate) =>
-					candidate.sequence < oldest.sequence ? candidate : oldest,
-				);
+				if (!this.oldest) break;
+				rejected = this.oldest;
 				dropped = policy === "drop-oldest";
 			}
 			if (!this.remove(rejected)) break;
 			evictions.push({ task: rejected, dropped });
 		}
 		return evictions;
+	}
+
+	private promoteToHeap(): void {
+		this.heapMode = true;
+		let current = this.oldest;
+		while (current) {
+			current.queueIndex = this.items.length;
+			this.items.push(current);
+			current = current.nextQueued;
+		}
+		for (let index = (this.items.length >> 1) - 1; index >= 0; index--) {
+			this.siftDown(index);
+		}
+	}
+
+	private siftUp(startIndex: number): void {
+		let index = startIndex;
+		const task = this.items[index];
+		while (index > 0) {
+			const parentIndex = (index - 1) >> 1;
+			const parent = this.items[parentIndex];
+			if (
+				parent.priority > task.priority ||
+				(parent.priority === task.priority && parent.sequence <= task.sequence)
+			) {
+				break;
+			}
+			this.items[index] = parent;
+			parent.queueIndex = index;
+			index = parentIndex;
+		}
+		this.items[index] = task;
+		task.queueIndex = index;
+	}
+
+	private siftDown(startIndex: number): void {
+		let index = startIndex;
+		const task = this.items[index];
+		const firstLeaf = this.items.length >> 1;
+		while (index < firstLeaf) {
+			let childIndex = index * 2 + 1;
+			let child = this.items[childIndex];
+			const rightIndex = childIndex + 1;
+			if (rightIndex < this.items.length) {
+				const right = this.items[rightIndex];
+				if (
+					right.priority > child.priority ||
+					(right.priority === child.priority && right.sequence < child.sequence)
+				) {
+					childIndex = rightIndex;
+					child = right;
+				}
+			}
+			if (
+				task.priority > child.priority ||
+				(task.priority === child.priority && task.sequence <= child.sequence)
+			) {
+				break;
+			}
+			this.items[index] = child;
+			child.queueIndex = index;
+			index = childIndex;
+		}
+		this.items[index] = task;
+		task.queueIndex = index;
 	}
 }

--- a/packages/comlink-worker-pool/src/internal/termination.ts
+++ b/packages/comlink-worker-pool/src/internal/termination.ts
@@ -40,11 +40,17 @@ export class TerminationController {
 	}
 
 	allExhausted(): boolean {
-		return [...this.records.values()].every((record) => record.exhausted);
+		for (const record of this.records.values()) {
+			if (!record.exhausted) return false;
+		}
+		return true;
 	}
 
 	hasRetryableWorker(): boolean {
-		return [...this.records.values()].some((record) => !record.exhausted);
+		for (const record of this.records.values()) {
+			if (!record.exhausted) return true;
+		}
+		return false;
 	}
 
 	quarantine(worker: Worker, workerId?: number): TerminationRecord {

--- a/scripts/benchmark-worker-pool.ts
+++ b/scripts/benchmark-worker-pool.ts
@@ -114,8 +114,8 @@ async function measureWorkerChurn(workerTotal: number): Promise<number> {
 	for (let value = 0; value < workerTotal; value++) {
 		checksum += await pool.run("run", [value]);
 	}
-	const elapsedMs = performance.now() - startedAt;
 	await pool.close();
+	const elapsedMs = performance.now() - startedAt;
 
 	const expectedChecksum = ((workerTotal - 1) * workerTotal) / 2;
 	if (
@@ -167,8 +167,12 @@ async function collectSamples(
 	const samples: number[] = [];
 	for (let run = 0; run < runCount; run++) samples.push(await measure());
 	samples.sort((left, right) => left - right);
+	const middle = Math.floor(samples.length / 2);
 	return {
-		medianMs: samples[Math.floor(samples.length / 2)],
+		medianMs:
+			samples.length % 2 === 0
+				? (samples[middle - 1] + samples[middle]) / 2
+				: samples[middle],
 		p95Ms: samples[Math.ceil(samples.length * 0.95) - 1],
 	};
 }

--- a/scripts/benchmark-worker-pool.ts
+++ b/scripts/benchmark-worker-pool.ts
@@ -8,9 +8,36 @@ class BenchmarkWorker extends EventTarget {
 	public terminate(): void {}
 }
 
-const taskCount = Number(process.env.WORKER_POOL_BENCHMARK_TASKS ?? 10_000);
+interface WorkerCounters {
+	creations: number;
+	terminations: number;
+}
+
+class CountingBenchmarkWorker extends EventTarget {
+	constructor(private readonly counters: WorkerCounters) {
+		super();
+	}
+
+	public terminate(): void {
+		this.counters.terminations++;
+	}
+}
+
+const taskCount = Number(process.env.WORKER_POOL_BENCHMARK_TASKS ?? 50_000);
+const workerChurnCount = Number(
+	process.env.WORKER_POOL_BENCHMARK_CHURN_WORKERS ?? 10_000,
+);
+const workerBurstCount = Number(
+	process.env.WORKER_POOL_BENCHMARK_BURST_WORKERS ?? 1_000,
+);
 const runCount = Number(process.env.WORKER_POOL_BENCHMARK_RUNS ?? 5);
-const budgetMs = Number(process.env.WORKER_POOL_BENCHMARK_BUDGET_MS ?? 2_000);
+const budgetMs = Number(process.env.WORKER_POOL_BENCHMARK_BUDGET_MS ?? 500);
+const churnBudgetMs = Number(
+	process.env.WORKER_POOL_BENCHMARK_CHURN_BUDGET_MS ?? 250,
+);
+const burstBudgetMs = Number(
+	process.env.WORKER_POOL_BENCHMARK_BURST_BUDGET_MS ?? 100,
+);
 
 function assertPositiveInteger(value: number, label: string): void {
 	if (!Number.isSafeInteger(value) || value <= 0) {
@@ -18,13 +45,25 @@ function assertPositiveInteger(value: number, label: string): void {
 	}
 }
 
-assertPositiveInteger(taskCount, "WORKER_POOL_BENCHMARK_TASKS");
-assertPositiveInteger(runCount, "WORKER_POOL_BENCHMARK_RUNS");
-if (!Number.isFinite(budgetMs) || budgetMs <= 0) {
-	throw new Error("WORKER_POOL_BENCHMARK_BUDGET_MS must be positive");
+for (const [value, label] of [
+	[taskCount, "WORKER_POOL_BENCHMARK_TASKS"],
+	[workerChurnCount, "WORKER_POOL_BENCHMARK_CHURN_WORKERS"],
+	[workerBurstCount, "WORKER_POOL_BENCHMARK_BURST_WORKERS"],
+	[runCount, "WORKER_POOL_BENCHMARK_RUNS"],
+] as const) {
+	assertPositiveInteger(value, label);
+}
+for (const [value, label] of [
+	[budgetMs, "WORKER_POOL_BENCHMARK_BUDGET_MS"],
+	[churnBudgetMs, "WORKER_POOL_BENCHMARK_CHURN_BUDGET_MS"],
+	[burstBudgetMs, "WORKER_POOL_BENCHMARK_BURST_BUDGET_MS"],
+] as const) {
+	if (!Number.isFinite(value) || value <= 0) {
+		throw new Error(`${label} must be positive`);
+	}
 }
 
-async function measure(taskTotal: number): Promise<number> {
+async function measureTasks(taskTotal: number): Promise<number> {
 	const pool = new WorkerPool<BenchmarkApi>({
 		maxConcurrentTasksPerWorker: 1,
 		maxQueueSize: taskTotal,
@@ -58,35 +97,139 @@ async function measure(taskTotal: number): Promise<number> {
 	return elapsedMs;
 }
 
-await measure(Math.min(1_000, taskCount));
+async function measureWorkerChurn(workerTotal: number): Promise<number> {
+	const counters: WorkerCounters = { creations: 0, terminations: 0 };
+	const pool = new WorkerPool<BenchmarkApi>({
+		maxTasksPerWorker: 1,
+		proxyFactory: () => ({ run: async (value: number) => value }),
+		size: 1,
+		taskTimeoutMs: false,
+		workerFactory: () => {
+			counters.creations++;
+			return new CountingBenchmarkWorker(counters) as unknown as Worker;
+		},
+	});
+	let checksum = 0;
+	const startedAt = performance.now();
+	for (let value = 0; value < workerTotal; value++) {
+		checksum += await pool.run("run", [value]);
+	}
+	const elapsedMs = performance.now() - startedAt;
+	await pool.close();
 
-const samples: number[] = [];
-for (let run = 0; run < runCount; run += 1) {
-	samples.push(await measure(taskCount));
+	const expectedChecksum = ((workerTotal - 1) * workerTotal) / 2;
+	if (
+		checksum !== expectedChecksum ||
+		counters.creations !== workerTotal ||
+		counters.terminations !== workerTotal
+	) {
+		throw new Error(
+			`worker churn ended in an invalid state: ${counters.creations} created, ${counters.terminations} terminated, checksum ${checksum}`,
+		);
+	}
+	return elapsedMs;
 }
-samples.sort((left, right) => left - right);
 
-const medianMs = samples[Math.floor(samples.length / 2)];
-const p95Ms = samples[Math.ceil(samples.length * 0.95) - 1];
-const tasksPerSecond = Math.round(taskCount / (medianMs / 1_000));
+async function measureWorkerBurst(workerTotal: number): Promise<number> {
+	const counters: WorkerCounters = { creations: 0, terminations: 0 };
+	const pool = new WorkerPool<BenchmarkApi>({
+		proxyFactory: () => ({ run: async (value: number) => value }),
+		size: workerTotal,
+		taskTimeoutMs: false,
+		workerFactory: () => {
+			counters.creations++;
+			return new CountingBenchmarkWorker(counters) as unknown as Worker;
+		},
+	});
+	const startedAt = performance.now();
+	const results = await Promise.all(
+		Array.from({ length: workerTotal }, (_, value) => pool.run("run", [value])),
+	);
+	await pool.close();
+	const elapsedMs = performance.now() - startedAt;
+	const checksum = results.reduce((total, value) => total + value, 0);
+	const expectedChecksum = ((workerTotal - 1) * workerTotal) / 2;
+	if (
+		checksum !== expectedChecksum ||
+		counters.creations !== workerTotal ||
+		counters.terminations !== workerTotal
+	) {
+		throw new Error(
+			`worker burst ended in an invalid state: ${counters.creations} created, ${counters.terminations} terminated, checksum ${checksum}`,
+		);
+	}
+	return elapsedMs;
+}
+
+async function collectSamples(
+	measure: () => Promise<number>,
+): Promise<{ medianMs: number; p95Ms: number }> {
+	const samples: number[] = [];
+	for (let run = 0; run < runCount; run++) samples.push(await measure());
+	samples.sort((left, right) => left - right);
+	return {
+		medianMs: samples[Math.floor(samples.length / 2)],
+		p95Ms: samples[Math.ceil(samples.length * 0.95) - 1],
+	};
+}
+
+await measureTasks(Math.min(1_000, taskCount));
+await measureWorkerChurn(Math.min(100, workerChurnCount));
+await measureWorkerBurst(Math.min(100, workerBurstCount));
+
+const taskSamples = await collectSamples(() => measureTasks(taskCount));
+const churnSamples = await collectSamples(() =>
+	measureWorkerChurn(workerChurnCount),
+);
+const burstSamples = await collectSamples(() =>
+	measureWorkerBurst(workerBurstCount),
+);
 
 console.log(
 	JSON.stringify(
 		{
 			budgetMs,
-			medianMs: Number(medianMs.toFixed(2)),
-			p95Ms: Number(p95Ms.toFixed(2)),
+			medianMs: Number(taskSamples.medianMs.toFixed(2)),
+			p95Ms: Number(taskSamples.p95Ms.toFixed(2)),
 			runs: runCount,
 			taskCount,
-			tasksPerSecond,
+			tasksPerSecond: Math.round(taskCount / (taskSamples.medianMs / 1_000)),
+			workerChurn: {
+				budgetMs: churnBudgetMs,
+				medianMs: Number(churnSamples.medianMs.toFixed(2)),
+				p95Ms: Number(churnSamples.p95Ms.toFixed(2)),
+				workerCount: workerChurnCount,
+				workersPerSecond: Math.round(
+					workerChurnCount / (churnSamples.medianMs / 1_000),
+				),
+			},
+			workerBurst: {
+				budgetMs: burstBudgetMs,
+				medianMs: Number(burstSamples.medianMs.toFixed(2)),
+				p95Ms: Number(burstSamples.p95Ms.toFixed(2)),
+				workerCount: workerBurstCount,
+				workersPerSecond: Math.round(
+					workerBurstCount / (burstSamples.medianMs / 1_000),
+				),
+			},
 		},
 		null,
 		2,
 	),
 );
 
-if (p95Ms > budgetMs) {
+if (taskSamples.p95Ms > budgetMs) {
 	throw new Error(
-		`worker-pool benchmark exceeded its ${budgetMs} ms p95 budget (${p95Ms.toFixed(2)} ms)`,
+		`worker-pool benchmark exceeded its ${budgetMs} ms task p95 budget (${taskSamples.p95Ms.toFixed(2)} ms)`,
+	);
+}
+if (churnSamples.p95Ms > churnBudgetMs) {
+	throw new Error(
+		`worker-pool benchmark exceeded its ${churnBudgetMs} ms churn p95 budget (${churnSamples.p95Ms.toFixed(2)} ms)`,
+	);
+}
+if (burstSamples.p95Ms > burstBudgetMs) {
+	throw new Error(
+		`worker-pool benchmark exceeded its ${burstBudgetMs} ms burst p95 budget (${burstSamples.p95Ms.toFixed(2)} ms)`,
 	);
 }


### PR DESCRIPTION
## What has been done?

Hardened `comlink-worker-pool` so reentrant shutdown, abort-during-registration, and proxy-setup failures cannot leave workers untracked or execute settled work. Also cut spawn/dispatch/teardown overhead sharply: the same 10k-task harness improved from ~90k tasks/s (median 110.83 ms) to ~1.49M tasks/s (median 6.71 ms), about 16.5× higher median throughput.

Recommended changelog: `bug`

## Key features

- Shutdown waits for in-progress worker construction and quarantines any worker returned during reentrant close before `terminated` resolves.
- Abort settlement is reentrancy-safe: cancelled tasks cannot enter dispatch after settlement.
- Adaptive FIFO→heap queue keeps the common zero-priority path O(1) and preserves drain order under mixed priorities.
- Measured perf (synthetic workers, same harness):
  - 10k tasks: 110.83 ms → 6.71 ms median; 90,229 → 1,490,109 tasks/s
  - Final verify run: ~1.43M tasks/s; ~615k sequential workers/s; ~723k burst workers/s

## Implementation details

- Track unmanaged construction with `managed` + `workerCreationsInFlight`, install failure listeners before proxy construction, and fully unwind partial listener registration.
- Constant-time idle-worker reuse and indexed worker removal; gate event object allocation behind `onEvent`.
- Runtime benchmark now reports task throughput, sequential worker churn, and burst create/teardown against p95 budgets.
- Regression coverage for reentrant shutdown, abort-during-registration, and construction-time failures.

## How to check/test

```bash
bun run verify
```

Verified in this session:

- `bun run verify` passed (lint, typecheck, 100 tests with 100% line coverage, audit, builds, package validation, playground build, runtime + bundle budgets).
- Lifecycle stress: `bun test --rerun-each 20 packages/comlink-worker-pool/src` → 1480 pass / 0 fail.
- Adaptive scheduler fuzz: 200 seeds × 2000 ops = 400k ops passed.
- Runtime benchmark (synthetic workers): ~1.43M tasks/s; ~615k sequential workers/s; ~723k burst workers/s.
- Real browser workers: Chromium 3/3 and Firefox 3/3 passed. WebKit could not launch on this macOS 14 host (`Unknown setting: PushAPIEnabled` before page/worker code).

## Self-check

- [x] Change is cohesive and scoped to worker-pool lifecycle/perf
- [x] Tests updated for the fixed failure modes
- [x] Docs/changeset updated for shutdown guarantees and benchmark env vars
- [x] No secrets or unrelated agent docs included (`.kiro/` left untracked)
- [ ] WebKit real-worker CI path re-verified on a supported runner


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker-pool shutdown reliability during worker creation and reentrant shutdown scenarios.
  * Prevented cancelled tasks from starting, including when cancellation occurs during listener setup.
  * Improved handling of worker failures during initialization and proxy setup.
  * Enhanced scheduling performance and worker availability management.

* **Documentation**
  * Expanded benchmark guidance and clarified shutdown behavior, including in-progress worker construction.

* **Tests**
  * Added regression coverage for cancellation, initialization failures, and reentrant shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->