### PR TITLE
Fix the package release ownership model

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
 		{ "repo": "https://github.com/natanelia/comlink-worker-pool" }
 	],
 	"commit": false,
-	"fixed": [],
+	"fixed": [["comlink-worker-pool", "comlink-worker-pool-react"]],
 	"linked": [],
 	"access": "public",
 	"baseBranch": "main",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,31 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Materialize pending Changesets
         run: bun run version
+      - name: Validate publishable package versions
+        run: |
+          node <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const packagePaths = [
+            "packages/comlink-worker-pool/package.json",
+            "packages/comlink-worker-pool-react/package.json",
+          ];
+          const packages = packagePaths.map((path) =>
+            JSON.parse(readFileSync(path, "utf8")),
+          );
+          const versions = new Set(packages.map(({ version }) => version));
+          if (versions.size !== 1) {
+            throw new Error(
+              `Publishable packages must share one version; found ${[
+                ...versions,
+              ].join(", ")}`,
+            );
+          }
+          console.log(
+            `Validated lockstep release ${packages
+              .map(({ name, version }) => `${name}@${version}`)
+              .join(", ")}`,
+          );
+          NODE
       - name: Validate generated version files
         run: bun run lint && git diff --check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           publish: bun run release
           commit: "chore: version packages"
           title: "chore: version packages"
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The runtime harness measures task throughput, sequential worker churn, and burst
 
 [Changesets](https://github.com/changesets/changesets) owns package versioning and the release pull request. Every package-facing change should include a changeset. Merges to `main` run the release workflow, which updates the version PR or publishes approved versions.
 
+The two published packages form one fixed Changesets group and always share a version. The custom release command owns the single aggregate `v<version>` GitHub Release; the Changesets action only coordinates versioning and publication.
+
 To publish the versioned packages to npm and create the matching GitHub Release in one command, authenticate with both npm and GitHub, ensure the release commit is pushed to `origin`, and run:
 
 ```bash


### PR DESCRIPTION
## What changed

- Configure `comlink-worker-pool` and `comlink-worker-pool-react` as one fixed Changesets group, so valid release PRs cannot leave the publishable packages on different versions.
- Disable Changesets Action's package-specific GitHub Releases because `scripts/release.mjs` already owns the aggregate `v<version>` release.
- Validate the lockstep version invariant in the `version-preview` CI job after Changesets materializes pending versions.
- Document the intended single-owner release model.

## Why

The custom release script rejects publishable packages with different versions, but Changesets previously allowed independent versioning. The workflow also allowed both the custom script and Changesets Action to create GitHub Releases. A React-only changeset could therefore block publication, while a successful lockstep release could create two competing sets of releases.

## Validation

- Compared the branch against `main`: four focused files, no unrelated changes.
- The new assertion runs after `bun run version`, so it validates the exact package versions that the release workflow would publish.
- All nine GitHub Actions jobs pass, including lint, typecheck, unit tests, coverage, security audit, lockstep version preview, builds/package validation, Node 18 consumers, and Chromium/Firefox/WebKit browser tests.