### PR TITLE
Keep React worker-pool option refs commit-safe

### DIFF
--- a/.changeset/committed-worker-refs.md
+++ b/.changeset/committed-worker-refs.md
@@ -1,0 +1,5 @@
+---
+"comlink-worker-pool-react": patch
+---
+
+Commit worker-pool callbacks and factories before publishing them to the live pool so suspended or abandoned React renders cannot leak uncommitted options.

--- a/packages/comlink-worker-pool-react/src/useWorkerPool.regression.test.tsx
+++ b/packages/comlink-worker-pool-react/src/useWorkerPool.regression.test.tsx
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { useLayoutEffect, useRef } from "react";
+import {
+	type ReactNode,
+	Suspense,
+	startTransition,
+	useLayoutEffect,
+	useRef,
+} from "react";
 import { useWorkerPool } from "./useWorkerPool";
 
 class RegressionWorker extends EventTarget {
@@ -38,6 +44,76 @@ describe("useWorkerPool - regression coverage", () => {
 		});
 		unmount();
 	});
+
+	it("does not publish observers from an abandoned suspended render", async () => {
+		interface Api {
+			echo(value: string): Promise<string>;
+		}
+		let releaseSuspension!: () => void;
+		let shouldSuspend = true;
+		const suspension = new Promise<void>((resolve) => {
+			releaseSuspension = resolve;
+		});
+		const observedLabels: string[] = [];
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<Suspense fallback={null}>{children}</Suspense>
+		);
+		const { result, rerender, unmount } = renderHook(
+			({ label, suspend }: { label: string; suspend: boolean }) => {
+				const pool = useWorkerPool<Api>({
+					poolSize: 1,
+					workerFactory: () => new RegressionWorker() as unknown as Worker,
+					proxyFactory: () => ({ echo: async (value) => value }),
+					onEvent: () => {
+						observedLabels.push(label);
+					},
+				});
+				if (suspend && shouldSuspend) throw suspension;
+				return { label, pool };
+			},
+			{
+				initialProps: { label: "committed", suspend: false },
+				wrapper,
+			},
+		);
+		await waitFor(() => expect(result.current.pool.poolStatus).toBe("ready"));
+		const api = result.current.pool.api;
+		if (!api) throw new Error("Worker pool API was not initialized");
+
+		act(() => {
+			startTransition(() => {
+				rerender({ label: "next", suspend: true });
+			});
+		});
+		expect(result.current.label).toBe("committed");
+
+		observedLabels.length = 0;
+		await act(async () => {
+			await expect(api.echo("first")).resolves.toBe("first");
+		});
+		expect(observedLabels.length).toBeGreaterThan(0);
+		expect(observedLabels.every((label) => label === "committed")).toBe(true);
+
+		shouldSuspend = false;
+		await act(async () => {
+			releaseSuspension();
+			await suspension;
+		});
+		await waitFor(() => expect(result.current.label).toBe("next"));
+
+		observedLabels.length = 0;
+		await act(async () => {
+			await expect(api.echo("second")).resolves.toBe("second");
+		});
+		expect(observedLabels.length).toBeGreaterThan(0);
+		expect(observedLabels.every((label) => label === "next")).toBe(true);
+
+		await act(async () => {
+			await result.current.pool.close();
+		});
+		unmount();
+	});
+
 	it("keeps retained calls from obsolete pool generations state-inert", async () => {
 		interface Api {
 			add(left: number, right: number): Promise<number>;

--- a/packages/comlink-worker-pool-react/src/useWorkerPool.ts
+++ b/packages/comlink-worker-pool-react/src/useWorkerPool.ts
@@ -17,6 +17,14 @@ import {
 const useCommittedLayoutEffect =
 	typeof window === "undefined" ? useEffect : useLayoutEffect;
 
+function useCommittedRef<T>(value: T) {
+	const ref = useRef(value);
+	useCommittedLayoutEffect(() => {
+		ref.current = value;
+	}, [value]);
+	return ref;
+}
+
 export interface ProxyDefault {
 	// biome-ignore lint/suspicious/noExplicitAny: worker APIs may have arbitrary signatures
 	[key: string]: (...args: any[]) => unknown;
@@ -124,20 +132,15 @@ export function useWorkerPool<TProxy extends CallableProxy<TProxy>>(
 	const generationRef = useRef(0);
 	const latestCallIdRef = useRef(0);
 	const poolRef = useRef<WorkerPool<TProxy> | null>(null);
-	const statsCallbackRef = useRef(options.onUpdateStats);
-	const eventCallbackRef = useRef(options.onEvent);
-	const workerFactoryRef = useRef(options.workerFactory);
-	const proxyFactoryRef = useRef(options.proxyFactory);
-	const proxyCleanupRef = useRef(options.proxyCleanup);
-	const workerTerminatorRef = useRef(options.workerTerminator);
-	const terminationErrorCallbackRef = useRef(options.onWorkerTerminationError);
-	statsCallbackRef.current = options.onUpdateStats;
-	eventCallbackRef.current = options.onEvent;
-	workerFactoryRef.current = options.workerFactory;
-	proxyFactoryRef.current = options.proxyFactory;
-	proxyCleanupRef.current = options.proxyCleanup;
-	workerTerminatorRef.current = options.workerTerminator;
-	terminationErrorCallbackRef.current = options.onWorkerTerminationError;
+	const statsCallbackRef = useCommittedRef(options.onUpdateStats);
+	const eventCallbackRef = useCommittedRef(options.onEvent);
+	const workerFactoryRef = useCommittedRef(options.workerFactory);
+	const proxyFactoryRef = useCommittedRef(options.proxyFactory);
+	const proxyCleanupRef = useCommittedRef(options.proxyCleanup);
+	const workerTerminatorRef = useCommittedRef(options.workerTerminator);
+	const terminationErrorCallbackRef = useCommittedRef(
+		options.onWorkerTerminationError,
+	);
 
 	const {
 		poolSize,

--- a/packages/comlink-worker-pool-react/src/useWorkerPool.ts
+++ b/packages/comlink-worker-pool-react/src/useWorkerPool.ts
@@ -17,14 +17,6 @@ import {
 const useCommittedLayoutEffect =
 	typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-function useCommittedRef<T>(value: T) {
-	const ref = useRef(value);
-	useCommittedLayoutEffect(() => {
-		ref.current = value;
-	}, [value]);
-	return ref;
-}
-
 export interface ProxyDefault {
 	// biome-ignore lint/suspicious/noExplicitAny: worker APIs may have arbitrary signatures
 	[key: string]: (...args: any[]) => unknown;
@@ -132,15 +124,13 @@ export function useWorkerPool<TProxy extends CallableProxy<TProxy>>(
 	const generationRef = useRef(0);
 	const latestCallIdRef = useRef(0);
 	const poolRef = useRef<WorkerPool<TProxy> | null>(null);
-	const statsCallbackRef = useCommittedRef(options.onUpdateStats);
-	const eventCallbackRef = useCommittedRef(options.onEvent);
-	const workerFactoryRef = useCommittedRef(options.workerFactory);
-	const proxyFactoryRef = useCommittedRef(options.proxyFactory);
-	const proxyCleanupRef = useCommittedRef(options.proxyCleanup);
-	const workerTerminatorRef = useCommittedRef(options.workerTerminator);
-	const terminationErrorCallbackRef = useCommittedRef(
-		options.onWorkerTerminationError,
-	);
+	const statsCallbackRef = useRef(options.onUpdateStats);
+	const eventCallbackRef = useRef(options.onEvent);
+	const workerFactoryRef = useRef(options.workerFactory);
+	const proxyFactoryRef = useRef(options.proxyFactory);
+	const proxyCleanupRef = useRef(options.proxyCleanup);
+	const workerTerminatorRef = useRef(options.workerTerminator);
+	const terminationErrorCallbackRef = useRef(options.onWorkerTerminationError);
 
 	const {
 		poolSize,
@@ -158,6 +148,25 @@ export function useWorkerPool<TProxy extends CallableProxy<TProxy>>(
 		terminationAttemptTimeoutMs,
 		reconfigureKey,
 	} = options;
+
+	// Publish dynamic options only after React commits this render.
+	useCommittedLayoutEffect(() => {
+		statsCallbackRef.current = options.onUpdateStats;
+		eventCallbackRef.current = options.onEvent;
+		workerFactoryRef.current = options.workerFactory;
+		proxyFactoryRef.current = options.proxyFactory;
+		proxyCleanupRef.current = options.proxyCleanup;
+		workerTerminatorRef.current = options.workerTerminator;
+		terminationErrorCallbackRef.current = options.onWorkerTerminationError;
+	}, [
+		options.onUpdateStats,
+		options.onEvent,
+		options.workerFactory,
+		options.proxyFactory,
+		options.proxyCleanup,
+		options.workerTerminator,
+		options.onWorkerTerminationError,
+	]);
 
 	useCommittedLayoutEffect(() => {
 		activeCallBindingRef.current = callBinding;


### PR DESCRIPTION
## What changed

- Replace render-time writes to live worker-pool option refs with one commit-phase update over ordinary React refs.
- Apply the commit-safe behavior to statistics, event, and termination-error observers as well as worker, proxy, cleanup, and terminator factories.
- Preserve the existing behavior where callback identity changes do not recreate the pool and factory changes are applied only when `reconfigureKey` recreates it.
- Add concurrent React regression coverage using `startTransition` and `Suspense`.

## Why

React may start a render and later abandon it. The previous implementation wrote shared refs during render, allowing an observer or factory from an uncommitted suspended tree to become visible to the already-committed live pool. This could deliver events to callbacks that closed over UI state the user never saw.

## Regression coverage

The new test:

1. Commits an observer labelled `committed`.
2. Starts a transition to an observer labelled `next` and suspends that render.
3. Invokes the existing pool while the transition is abandoned and verifies every event still reaches `committed`.
4. Resolves the suspension, commits `next`, invokes again, and verifies subsequent events reach `next`.

## Validation

- Compared against `main`: one focused implementation file, one regression test, and one React-package changeset.
- The implementation was typechecked with a strict TypeScript 5.8 harness.
- All nine GitHub Actions jobs pass, including lint, typecheck, unit tests, coverage, security audit, Changesets version preview, builds/package validation, Node 18 consumers, and Chromium/Firefox/WebKit browser tests.