### PR TITLE
Model worker handles as disposable leases

### DIFF
--- a/packages/comlink-worker-pool-react/README.md
+++ b/packages/comlink-worker-pool-react/README.md
@@ -80,9 +80,9 @@ The hook creates its pool after the component commits and closes it during clean
 | `result` | Result of the latest tracked call |
 | `error` | Latest call or initialization error |
 | `call(method, ...args)` | Typed method invocation with latest-call state |
-| `close()` | Awaitable immediate shutdown with a termination report |
+| `close()` | Awaitable immediate shutdown with a handle-cleanup report |
 
-When `poolSize` is omitted, the default leaves one reported logical core free and caps the pool at four workers. Pool size, lifecycle, concurrency, queue, and timeout option changes recreate the owned pool.
+When `poolSize` is omitted, the default leaves one reported logical core free and caps the pool at four worker handles. Pool size, lifecycle, concurrency, queue, and timeout option changes recreate the owned pool.
 
 Inline factory identities do not recreate the pool. Increment or replace `reconfigureKey` when a new `workerFactory`, `proxyFactory`, `proxyCleanup`, or `workerTerminator` must take effect.
 
@@ -102,7 +102,7 @@ For overlapping hook calls, only the latest-started invocation updates tracked s
 - `maxQueueSize`, `queueOverflowPolicy`, and `queueTimeoutMs`
 - `taskTimeoutMs`
 - `workerIdleTimeoutMs`, `maxTasksPerWorker`, and `maxWorkerLifetimeMs`
-- termination retry, timeout, buffer, and custom terminator options
+- handle-cleanup retry, timeout, buffer, and custom terminator options
 - `onUpdateStats`, `onEvent`, and `onWorkerTerminationError`
 
 See the [core package documentation](../comlink-worker-pool/README.md) for exact semantics.

--- a/packages/comlink-worker-pool-react/src/useWorkerPool.ts
+++ b/packages/comlink-worker-pool-react/src/useWorkerPool.ts
@@ -58,19 +58,22 @@ interface UseWorkerPoolCommonOptions<TProxy extends CallableProxy<TProxy>> {
 	queueOverflowPolicy?: WorkerPoolOptions<TProxy>["queueOverflowPolicy"];
 	/** Default maximum time a task may wait in the queue. */
 	queueTimeoutMs?: WorkerPoolOptions<TProxy>["queueTimeoutMs"];
-	/** Rejects overlong tasks and recycles their worker (five-minute default). */
+	/**
+	 * Rejects overlong tasks and disposes their handle (five-minute default).
+	 * SharedWorker work may continue after its connection port closes.
+	 */
 	taskTimeoutMs?: WorkerPoolOptions<TProxy>["taskTimeoutMs"];
 	/** Cleans up resources owned by a worker proxy. */
 	proxyCleanup?: (proxy: TProxy) => void;
-	/** Extra worker slots that preserve capacity after termination failure. */
+	/** Extra handle slots that preserve capacity after cleanup failure. */
 	terminationFailureWorkerBuffer?: WorkerPoolOptions<TProxy>["terminationFailureWorkerBuffer"];
-	/** Additional termination attempts after the initial attempt. */
+	/** Additional handle-cleanup attempts after the initial attempt. */
 	terminationRetryAttempts?: WorkerPoolOptions<TProxy>["terminationRetryAttempts"];
-	/** Initial exponential-backoff delay for termination retries. */
+	/** Initial exponential-backoff delay for handle-cleanup retries. */
 	terminationRetryDelayMs?: WorkerPoolOptions<TProxy>["terminationRetryDelayMs"];
-	/** Deadline for an asynchronous termination attempt. */
+	/** Deadline for an asynchronous handle-cleanup attempt. */
 	terminationAttemptTimeoutMs?: WorkerPoolOptions<TProxy>["terminationAttemptTimeoutMs"];
-	/** Receives termination-attempt failures without reconfiguring the pool. */
+	/** Receives handle-cleanup failures without reconfiguring the pool. */
 	onWorkerTerminationError?: WorkerPoolOptions<TProxy>["onWorkerTerminationError"];
 	/**
 	 * Explicitly recreates the pool when this value changes.
@@ -90,7 +93,7 @@ interface UseWorkerPoolEndpointOptions<
 	workerFactory: WorkerFactory<TWorker>;
 	/** Creates the proxy API for the worker. */
 	proxyFactory: (worker: TWorker) => TProxy;
-	/** Optional host-specific worker terminator. */
+	/** Optional host-specific worker-handle cleanup. */
 	workerTerminator?: WorkerTerminator<TWorker>;
 }
 

--- a/packages/comlink-worker-pool/README.md
+++ b/packages/comlink-worker-pool/README.md
@@ -102,7 +102,7 @@ const result = pool.run("fib", [42], {
 
 Higher numeric priorities run first. Equal priorities remain FIFO. `maxQueueSize` counts only waiting work, not running work. The default overflow policy rejects the new call with `WorkerPoolQueueFullError`; `"drop-oldest"` instead rejects the oldest queued call.
 
-Aborting queued work removes it immediately. Aborting active work rejects the caller's promise but does not forcibly interrupt worker code because that worker may host other concurrent calls. Its slot remains occupied until the underlying call finishes or the task timeout recycles the worker.
+Aborting queued work removes it immediately. Aborting active work rejects the caller's promise but does not forcibly interrupt worker code because that worker may host other concurrent calls. Its slot remains occupied until the underlying call finishes or the task timeout recycles the handle. A SharedWorker timeout closes only the pool's connection; it cannot stop work already running in the shared process.
 
 ## Shutdown
 
@@ -113,23 +113,23 @@ const drainReport = await pool.drain(); // finish accepted work
 const closeReport = await pool.close(); // reject accepted work immediately
 ```
 
-Both methods reject future calls, terminate workers, and return a `WorkerPoolShutdownReport`. The shared `pool.terminated` promise exposes the same final report.
+Both methods reject future calls, clean up every pool-owned handle, and return a `WorkerPoolShutdownReport`. Dedicated-worker cleanup calls `Worker.terminate()`; SharedWorker cleanup closes only the pool's connection port. A confirmed SharedWorker report therefore confirms connection disposal, not termination of the underlying shared process. The shared `pool.terminated` promise exposes the same final report.
 
-Shutdown completion also waits for synchronous worker construction already in progress. If a factory or proxy setup reenters shutdown, every worker it returns is quarantined and included in the final report before `terminated` resolves.
+Shutdown completion also waits for synchronous worker construction already in progress. If a factory or proxy setup reenters shutdown, every handle it returns is quarantined and included in the final report before `terminated` resolves.
 
 `terminateAll()` is the synchronous compatibility entry point. It begins immediate close and cleanup but does not await the final report.
 
-Worker termination is retried with bounded exponential backoff. A termination that cannot be confirmed is quarantined and remains visible in statistics. Replacement workers are limited by `terminationFailureWorkerBuffer`, preventing an unbounded number of potentially live workers.
+Handle cleanup is retried with bounded exponential backoff. Cleanup that cannot be confirmed is quarantined and remains visible in statistics. Replacement handles are limited by `terminationFailureWorkerBuffer`, preventing unbounded resource growth. Public option and error names retain their worker-termination terminology for compatibility.
 
 ## Observability
 
 Read a snapshot with `getStats()` or subscribe with `onUpdateStats`. Statistics include:
 
-- pool state, configured capacity, instantiated workers, and active tasks
+- pool state, configured capacity, instantiated handles, and active tasks
 - queue depth, capacity, remaining slots, and oldest queued task age
-- healthy and quarantined worker counts
+- healthy and quarantined handle counts
 - submitted, started, completed, failed, cancelled, timed out, and dropped task counters
-- termination failure counters
+- handle-cleanup failure counters
 
 `onEvent` receives structured task and worker events. Task arguments and results are intentionally excluded.
 
@@ -153,9 +153,9 @@ Observer exceptions and rejected thenables are isolated from scheduler behavior.
 
 | Option | Type | Behavior |
 | --- | --- | --- |
-| `size` | `number` | Maximum scheduler-managed workers |
-| `workerFactory` | `() => Worker \| SharedWorker` | Creates a fresh worker object whose lifecycle the pool owns |
-| `proxyFactory` | `(worker: Worker \| SharedWorker) => P` | Creates the worker API proxy; use `sharedWorker.port` as the Comlink endpoint |
+| `size` | `number` | Maximum scheduler-managed worker handles |
+| `workerFactory` | `() => Worker \| SharedWorker` | Creates a fresh handle whose lifecycle the pool owns |
+| `proxyFactory` | `(worker: Worker \| SharedWorker) => P` | Creates the handle's API proxy; use `sharedWorker.port` as the Comlink endpoint |
 | `maxConcurrentTasksPerWorker` | `number` | Per-worker concurrency, default `1` |
 | `maxQueueSize` | `number` | Maximum waiting tasks, default unlimited |
 | `queueOverflowPolicy` | `"reject" \| "drop-oldest"` | Full-queue behavior, default `"reject"` |
@@ -164,17 +164,17 @@ Observer exceptions and rejected thenables are isolated from scheduler behavior.
 | `workerIdleTimeoutMs` | `number` | Retires an idle worker after the duration |
 | `maxTasksPerWorker` | `number` | Retires a worker after assigned task count |
 | `maxWorkerLifetimeMs` | `number` | Retires a worker after the lifetime once idle |
-| `proxyCleanup` | `(proxy: P) => void` | Custom proxy cleanup before worker termination |
+| `proxyCleanup` | `(proxy: P) => void` | Custom proxy cleanup before handle disposal |
 | `onUpdateStats` | `(stats) => void \| PromiseLike<unknown>` | Receives live statistics; rejected thenables are isolated |
 | `onEvent` | `(event) => void \| PromiseLike<unknown>` | Receives structured scheduler events; rejected thenables are isolated |
-| `terminationFailureWorkerBuffer` | `number` | Extra physical-worker allowance for quarantined workers |
-| `terminationRetryAttempts` | `number` | Retries after the initial termination attempt, default `3` |
-| `terminationRetryDelayMs` | `number` | Initial retry delay, default `100` ms |
-| `terminationAttemptTimeoutMs` | `number` | Absolute deadline for each asynchronous termination attempt, default five seconds |
-| `workerTerminator` | `(worker) => void \| PromiseLike<unknown>` | Host-specific termination; defaults to `Worker.terminate()` or `SharedWorker.port.close()` |
-| `onWorkerTerminationError` | `(error) => void \| PromiseLike<unknown>` | Receives termination failures; rejected thenables are isolated |
+| `terminationFailureWorkerBuffer` | `number` | Extra handle allowance for quarantined cleanup |
+| `terminationRetryAttempts` | `number` | Retries after the initial cleanup attempt, default `3` |
+| `terminationRetryDelayMs` | `number` | Initial cleanup retry delay, default `100` ms |
+| `terminationAttemptTimeoutMs` | `number` | Deadline for each asynchronous cleanup attempt, default five seconds |
+| `workerTerminator` | `(worker) => void \| PromiseLike<unknown>` | Host-specific handle cleanup; defaults to `Worker.terminate()` or `SharedWorker.port.close()` |
+| `onWorkerTerminationError` | `(error) => void \| PromiseLike<unknown>` | Receives cleanup failures; rejected thenables are isolated |
 
-The default five-minute task timeout is the portable recovery mechanism for a worker that silently closes or never settles. Set it to `false` only for intentionally unbounded work. Timed-out calls are not retried because they may already have produced side effects.
+The default five-minute task timeout is the portable recovery mechanism for an endpoint that silently closes or never settles. Set it to `false` only for intentionally unbounded work. Timed-out calls are not retried because they may already have produced side effects. For SharedWorker connections, closing the timed-out port does not cancel remote work already executing.
 
 ## API
 

--- a/packages/comlink-worker-pool/src/WorkerPool.robustness.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.robustness.test.ts
@@ -356,6 +356,20 @@ describe("WorkerPool - lifecycle robustness", () => {
 		proxyFailurePool.terminateAll();
 	});
 
+	test("rejects invalid worker handles at the lease boundary", async () => {
+		const pool = new WorkerPool<{ run(): Promise<void> }>({
+			size: 1,
+			workerFactory: () => null as unknown as Worker,
+			proxyFactory: () => ({ run: async () => undefined }),
+		});
+
+		await expect(pool.run("run", [])).rejects.toThrow(
+			"workerFactory must return a Worker or SharedWorker object",
+		);
+		expect(pool.getStats()).toMatchObject({ workers: 0, queue: 0 });
+		await pool.close();
+	});
+
 	test("rejects invalid proxy values and cleans up their partial worker", async () => {
 		const worker = new ControlledWorker();
 		const pool = new WorkerPool<{ run(): Promise<void> }>({

--- a/packages/comlink-worker-pool/src/WorkerPool.shared-worker.test.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.shared-worker.test.ts
@@ -29,7 +29,7 @@ interface SharedApi {
 }
 
 describe("WorkerPool - SharedWorker lifecycle", () => {
-	test("closes the connection port during default termination", async () => {
+	test("closes the connection port during default handle cleanup", async () => {
 		const worker = new TestSharedWorker();
 		const pool = new WorkerPool<SharedApi>({
 			size: 1,

--- a/packages/comlink-worker-pool/src/WorkerPool.ts
+++ b/packages/comlink-worker-pool/src/WorkerPool.ts
@@ -21,9 +21,14 @@ import {
 	WorkerTaskTimeoutError,
 } from "./errors";
 import {
+	DEFAULT_DISPOSAL_ATTEMPT_TIMEOUT_MS,
+	DEFAULT_DISPOSAL_RETRY_ATTEMPTS,
+	DEFAULT_DISPOSAL_RETRY_DELAY_MS,
+	DisposalController,
+} from "./internal/disposal";
+import {
 	DEFAULT_TASK_TIMEOUT_MS,
 	MAX_TIMER_DELAY_MS,
-	type WorkerFailureListenerRegistration,
 	type WorkerMetadata,
 	assertFunction,
 	assertNonNegativeInteger,
@@ -35,26 +40,13 @@ import {
 } from "./internal/lifecycle";
 import { type ScheduledTask, SchedulerQueue } from "./internal/scheduler";
 import {
-	DEFAULT_TERMINATION_ATTEMPT_TIMEOUT_MS,
-	DEFAULT_TERMINATION_RETRY_ATTEMPTS,
-	DEFAULT_TERMINATION_RETRY_DELAY_MS,
-	TerminationController,
-} from "./internal/termination";
-import {
-	type BoundWorkerTerminator,
 	type WorkerHandle,
-	getWorkerFailureTargets,
-	terminateWorker,
+	type WorkerLease,
+	createWorkerLeaseFactory,
 } from "./worker";
 
 export * from "./contracts";
 export * from "./errors";
-
-interface WorkerBinding<TProxy> {
-	worker: WorkerHandle;
-	createProxy: () => TProxy;
-	terminate: BoundWorkerTerminator;
-}
 
 /** A lazy, bounded pool for proxying calls to Web Workers. */
 export class WorkerPool<
@@ -69,7 +61,7 @@ export class WorkerPool<
 	private readonly size: number;
 	private readonly onUpdate?: WorkerPoolObserver<WorkerPoolStats>;
 	private readonly onEvent?: WorkerPoolObserver<WorkerPoolEvent>;
-	private readonly createWorkerBinding: () => WorkerBinding<TProxy>;
+	private readonly createWorkerLease: () => WorkerLease<TProxy>;
 	private readonly workerIdleTimeoutMs?: number;
 	private readonly maxTasksPerWorker?: number;
 	private readonly maxWorkerLifetimeMs?: number;
@@ -79,9 +71,9 @@ export class WorkerPool<
 	private readonly queueTimeoutMs?: number;
 	private readonly taskTimeoutMs?: number;
 	private readonly proxyCleanup?: (proxy: TProxy) => void;
-	private readonly terminationFailureWorkerBuffer: number;
-	private readonly physicalWorkerLimit: number;
-	private readonly termination: TerminationController;
+	private readonly disposalFailureHandleBuffer: number;
+	private readonly physicalHandleLimit: number;
+	private readonly disposal: DisposalController;
 
 	private workers: WorkerMetadata<TProxy, TTask, TResult>[] = [];
 	private readonly queue = new SchedulerQueue<TTask, TResult>();
@@ -92,7 +84,7 @@ export class WorkerPool<
 	private nextTaskSequence = 0;
 	private accepting = true;
 	private drainRequested = false;
-	private terminationStarted = false;
+	private shutdownStarted = false;
 	private workerCreationsInProgress = 0;
 	private scheduling = false;
 	private rescheduleRequested = false;
@@ -106,7 +98,7 @@ export class WorkerPool<
 	private droppedTasks = 0;
 	private readonly knownWorkers = new WeakSet<object>();
 	private resolveTerminated!: (report: WorkerPoolShutdownReport) => void;
-	/** Resolves once every worker is confirmed terminated or cleanup is exhausted. */
+	/** Resolves once cleanup is confirmed or exhausted for every owned handle. */
 	public readonly terminated: Promise<WorkerPoolShutdownReport>;
 
 	constructor(options: WorkerPoolConfiguration<TProxy, TWorker>) {
@@ -162,19 +154,16 @@ export class WorkerPool<
 			options.taskTimeoutMs === false ? undefined : options.taskTimeoutMs,
 			"taskTimeoutMs",
 		);
-		const terminationFailureWorkerBuffer =
+		const disposalFailureHandleBuffer =
 			options.terminationFailureWorkerBuffer ??
 			Math.max(2, Math.floor(options.size / 2));
 		assertNonNegativeInteger(
-			terminationFailureWorkerBuffer,
+			disposalFailureHandleBuffer,
 			"terminationFailureWorkerBuffer",
 		);
-		const terminationRetryAttempts =
-			options.terminationRetryAttempts ?? DEFAULT_TERMINATION_RETRY_ATTEMPTS;
-		assertNonNegativeInteger(
-			terminationRetryAttempts,
-			"terminationRetryAttempts",
-		);
+		const disposalRetryAttempts =
+			options.terminationRetryAttempts ?? DEFAULT_DISPOSAL_RETRY_ATTEMPTS;
+		assertNonNegativeInteger(disposalRetryAttempts, "terminationRetryAttempts");
 		assertPositiveDuration(
 			options.terminationRetryDelayMs,
 			"terminationRetryDelayMs",
@@ -183,7 +172,7 @@ export class WorkerPool<
 			options.terminationAttemptTimeoutMs,
 			"terminationAttemptTimeoutMs",
 		);
-		if (!Number.isSafeInteger(options.size + terminationFailureWorkerBuffer)) {
+		if (!Number.isSafeInteger(options.size + disposalFailureHandleBuffer)) {
 			throw new RangeError(
 				"size + terminationFailureWorkerBuffer must be a safe integer",
 			);
@@ -192,16 +181,11 @@ export class WorkerPool<
 		this.size = options.size;
 		this.onUpdate = options.onUpdateStats;
 		this.onEvent = options.onEvent;
-		const { workerFactory, proxyFactory, workerTerminator } = options;
-		this.createWorkerBinding = () => {
-			const worker = workerFactory();
-			return {
-				worker,
-				createProxy: () => proxyFactory(worker),
-				terminate: () =>
-					workerTerminator ? workerTerminator(worker) : terminateWorker(worker),
-			};
-		};
+		this.createWorkerLease = createWorkerLeaseFactory(
+			options.workerFactory,
+			options.proxyFactory,
+			options.workerTerminator,
+		);
 		this.workerIdleTimeoutMs = options.workerIdleTimeoutMs;
 		this.maxTasksPerWorker = options.maxTasksPerWorker;
 		this.maxWorkerLifetimeMs = options.maxWorkerLifetimeMs;
@@ -215,15 +199,15 @@ export class WorkerPool<
 				? undefined
 				: (options.taskTimeoutMs ?? DEFAULT_TASK_TIMEOUT_MS);
 		this.proxyCleanup = options.proxyCleanup;
-		this.terminationFailureWorkerBuffer = terminationFailureWorkerBuffer;
-		this.physicalWorkerLimit = options.size + terminationFailureWorkerBuffer;
-		this.termination = new TerminationController({
-			retryAttempts: terminationRetryAttempts,
+		this.disposalFailureHandleBuffer = disposalFailureHandleBuffer;
+		this.physicalHandleLimit = options.size + disposalFailureHandleBuffer;
+		this.disposal = new DisposalController({
+			retryAttempts: disposalRetryAttempts,
 			retryDelayMs:
-				options.terminationRetryDelayMs ?? DEFAULT_TERMINATION_RETRY_DELAY_MS,
+				options.terminationRetryDelayMs ?? DEFAULT_DISPOSAL_RETRY_DELAY_MS,
 			attemptTimeoutMs:
 				options.terminationAttemptTimeoutMs ??
-				DEFAULT_TERMINATION_ATTEMPT_TIMEOUT_MS,
+				DEFAULT_DISPOSAL_ATTEMPT_TIMEOUT_MS,
 			onFailure: (error) => {
 				if (this.onEvent) {
 					this._emit({
@@ -281,16 +265,16 @@ export class WorkerPool<
 		>;
 	}
 
-	/** Stops accepting work, finishes accepted calls, then shuts down all workers. */
+	/** Stops accepting work, finishes accepted calls, then cleans up all handles. */
 	public drain(): Promise<WorkerPoolShutdownReport> {
-		if (this.terminationStarted) return this.terminated;
+		if (this.shutdownStarted) return this.terminated;
 		this.accepting = false;
 		this.drainRequested = true;
 		this._next();
 		if (
 			this.queue.length > 0 &&
 			this.workers.length === 0 &&
-			this.termination.count === 0 &&
+			this.disposal.count === 0 &&
 			this.workerCreationsInProgress === 0
 		) {
 			// A bounded no-progress scheduling pass has no future trigger once the
@@ -309,12 +293,12 @@ export class WorkerPool<
 		return this.terminated;
 	}
 
-	/** Permanently closes the pool, rejects work, and starts bounded worker termination. */
+	/** Permanently closes the pool, rejects work, and starts bounded handle cleanup. */
 	public terminateAll(): void {
-		if (this.terminationStarted) return;
+		if (this.shutdownStarted) return;
 		this.accepting = false;
 		this.drainRequested = false;
-		this.terminationStarted = true;
+		this.shutdownStarted = true;
 		const reason = new WorkerPoolTerminatedError();
 
 		for (const item of this.queue.drain()) {
@@ -354,19 +338,19 @@ export class WorkerPool<
 			}
 		}
 
-		const physicalWorkerCount = this.workers.length + this.termination.count;
-		const uncreatedCapacity = this.terminationStarted
+		const physicalHandleCount = this.workers.length + this.disposal.count;
+		const uncreatedCapacity = this.shutdownStarted
 			? 0
 			: Math.max(
 					0,
 					Math.min(
 						this.size - this.workers.length,
-						this.physicalWorkerLimit - physicalWorkerCount,
+						this.physicalHandleLimit - physicalHandleCount,
 					),
 				);
 
 		return {
-			state: this.terminationStarted
+			state: this.shutdownStarted
 				? "closed"
 				: this.drainRequested
 					? "draining"
@@ -383,11 +367,11 @@ export class WorkerPool<
 				: null,
 			oldestQueuedTaskAgeMs:
 				oldestQueuedAt === null ? null : Math.max(0, now - oldestQueuedAt),
-			workers: physicalWorkerCount,
+			workers: physicalHandleCount,
 			healthyWorkers: this.workers.length,
-			quarantinedWorkers: this.termination.count,
-			terminationFailureWorkerBuffer: this.terminationFailureWorkerBuffer,
-			terminationFailures: this.termination.failures,
+			quarantinedWorkers: this.disposal.count,
+			terminationFailureWorkerBuffer: this.disposalFailureHandleBuffer,
+			terminationFailures: this.disposal.failures,
 			idleWorkers,
 			runningTasks,
 			availableForConcurrency,
@@ -551,7 +535,7 @@ export class WorkerPool<
 	}
 
 	private _next(): void {
-		if (this.terminationStarted) return;
+		if (this.shutdownStarted) return;
 		if (this.scheduling) {
 			this.rescheduleRequested = true;
 			return;
@@ -563,7 +547,7 @@ export class WorkerPool<
 			do {
 				const startedTasksBeforePass = this.startedTasks;
 				this.rescheduleRequested = false;
-				while (this.queue.length > 0 && !this.terminationStarted) {
+				while (this.queue.length > 0 && !this.shutdownStarted) {
 					let worker: WorkerMetadata<TProxy, TTask, TResult> | null;
 					try {
 						worker = this._getAvailableWorker();
@@ -591,7 +575,7 @@ export class WorkerPool<
 				} else {
 					retriedWithoutProgress = false;
 				}
-			} while (this.rescheduleRequested && !this.terminationStarted);
+			} while (this.rescheduleRequested && !this.shutdownStarted);
 		} finally {
 			this.scheduling = false;
 		}
@@ -616,10 +600,10 @@ export class WorkerPool<
 			return worker;
 		}
 
-		const physicalWorkerCount = this.workers.length + this.termination.count;
+		const physicalHandleCount = this.workers.length + this.disposal.count;
 		const canCreate =
 			this.workers.length < this.size &&
-			physicalWorkerCount < this.physicalWorkerLimit;
+			physicalHandleCount < this.physicalHandleLimit;
 		if (!canCreate) return this._findLeastLoadedWorker();
 
 		this.workerCreationsInProgress++;
@@ -643,7 +627,7 @@ export class WorkerPool<
 				});
 			}
 			if (!this._containsWorker(worker)) return null;
-			if (this.terminationStarted) {
+			if (this.shutdownStarted) {
 				this._removeWorker(worker, true, "shutdown");
 				return null;
 			}
@@ -653,7 +637,7 @@ export class WorkerPool<
 			return worker;
 		} finally {
 			this.workerCreationsInProgress--;
-			if (this.terminationStarted || this.drainRequested) this._updateStats();
+			if (this.shutdownStarted || this.drainRequested) this._updateStats();
 		}
 	}
 
@@ -682,23 +666,13 @@ export class WorkerPool<
 	}
 
 	private _createWorker(): WorkerMetadata<TProxy, TTask, TResult> {
-		const binding = this.createWorkerBinding();
-		const { worker } = binding;
-		if (
-			(typeof worker !== "object" && typeof worker !== "function") ||
-			!worker
-		) {
-			throw new TypeError(
-				"workerFactory must return a Worker or SharedWorker object",
-			);
-		}
-		if (this.knownWorkers.has(worker)) {
+		const lease = this.createWorkerLease();
+		if (this.knownWorkers.has(lease.identity)) {
 			throw new Error("workerFactory must return a fresh worker instance");
 		}
-		this.knownWorkers.add(worker);
+		this.knownWorkers.add(lease.identity);
 
 		const id = this.nextWorkerId++;
-		const failureListeners: WorkerFailureListenerRegistration[] = [];
 		// biome-ignore lint/style/useConst: listener setup must close over metadata before assignment.
 		let metadata: WorkerMetadata<TProxy, TTask, TResult> | undefined;
 		let constructionFailure: WorkerCrashedError | undefined;
@@ -717,17 +691,13 @@ export class WorkerPool<
 			}
 		};
 
+		let unsubscribeFailures!: () => void;
 		let proxy: TProxy | undefined;
 		try {
-			for (const { target, eventTypes } of getWorkerFailureTargets(worker)) {
-				for (const type of eventTypes) {
-					failureListeners.push({ target, type });
-					target.addEventListener(type, failureHandler);
-					if (constructionFailure) throw constructionFailure;
-				}
-			}
+			unsubscribeFailures = lease.subscribeToFailures(failureHandler);
+			if (constructionFailure) throw constructionFailure;
 
-			const createdProxy = binding.createProxy();
+			const createdProxy = lease.createProxy();
 			if (
 				(typeof createdProxy !== "object" &&
 					typeof createdProxy !== "function") ||
@@ -738,30 +708,29 @@ export class WorkerPool<
 			proxy = createdProxy;
 			if (constructionFailure) throw constructionFailure;
 		} catch (error) {
-			this._removeFailureListeners(failureHandler, failureListeners);
+			unsubscribeFailures?.();
 			if (proxy !== undefined) this._cleanupProxy(proxy);
-			const termination = this.termination.quarantine(
-				worker,
-				binding.terminate,
+			const disposal = this.disposal.quarantine(
+				lease.identity,
+				lease.dispose,
 				id,
 			);
-			this.termination.attempt(termination);
+			this.disposal.attempt(disposal);
 			throw constructionFailure ?? error;
 		}
 
 		metadata = {
 			id,
 			proxy,
-			worker,
-			terminate: binding.terminate,
+			identity: lease.identity,
+			dispose: lease.dispose,
+			unsubscribeFailures,
 			taskCount: 0,
 			createdAt: monotonicNow(),
 			activeTasks: new Set<ScheduledTask<TTask, TResult>>(),
 			poolIndex: -1,
 			markedForTermination: false,
 			managed: false,
-			failureHandler,
-			failureListeners,
 		};
 		return metadata;
 	}
@@ -855,7 +824,7 @@ export class WorkerPool<
 		worker.activeTasks.delete(item);
 		this._settleTask(item, succeeded, value);
 
-		if (!this._containsWorker(worker) || this.terminationStarted) return;
+		if (!this._containsWorker(worker) || this.shutdownStarted) return;
 		if (worker.activeTasks.size === 0) {
 			if (worker.markedForTermination || this._hasExpired(worker)) {
 				this._removeWorker(
@@ -1019,7 +988,7 @@ export class WorkerPool<
 	): void {
 		if (this.maxWorkerLifetimeMs === undefined) return;
 		const schedule = () => {
-			if (!this._containsWorker(worker) || this.terminationStarted) return;
+			if (!this._containsWorker(worker) || this.shutdownStarted) return;
 			const remaining =
 				(this.maxWorkerLifetimeMs as number) -
 				(monotonicNow() - worker.createdAt);
@@ -1054,7 +1023,7 @@ export class WorkerPool<
 			if (
 				!this._containsWorker(worker) ||
 				worker.activeTasks.size > 0 ||
-				this.terminationStarted
+				this.shutdownStarted
 			) {
 				return;
 			}
@@ -1095,7 +1064,7 @@ export class WorkerPool<
 		if (!worker.managed || (!force && worker.activeTasks.size > 0)) return;
 		let index = worker.poolIndex;
 		if (index < 0 || this.workers[index] !== worker) {
-			// Shutdown must still detach and terminate even if poolIndex drifted.
+			// Shutdown must still detach and dispose even if poolIndex drifted.
 			if (!force) return;
 			index = this.workers.lastIndexOf(worker);
 			if (index < 0) return;
@@ -1108,18 +1077,15 @@ export class WorkerPool<
 		}
 		worker.poolIndex = -1;
 		worker.managed = false;
-		const termination = this.termination.quarantine(
-			worker.worker,
-			worker.terminate,
+		const disposal = this.disposal.quarantine(
+			worker.identity,
+			worker.dispose,
 			worker.id,
 		);
 		this._clearIdleTimer(worker);
 		if (worker.lifetimeTimer !== undefined) clearTimeout(worker.lifetimeTimer);
 		worker.lifetimeTimer = undefined;
-		this._removeFailureListeners(
-			worker.failureHandler,
-			worker.failureListeners,
-		);
+		worker.unsubscribeFailures();
 		this._cleanupProxy(worker.proxy);
 		if (this.onEvent) {
 			this._emit({
@@ -1129,26 +1095,13 @@ export class WorkerPool<
 				reason,
 			});
 		}
-		this.termination.attempt(termination);
+		this.disposal.attempt(disposal);
 	}
 
 	private _containsWorker(
 		worker: WorkerMetadata<TProxy, TTask, TResult>,
 	): boolean {
 		return worker.managed;
-	}
-
-	private _removeFailureListeners(
-		failureHandler: (event: Event) => void,
-		failureListeners: WorkerFailureListenerRegistration[],
-	): void {
-		for (const { target, type } of failureListeners.splice(0)) {
-			try {
-				target.removeEventListener(type, failureHandler);
-			} catch {
-				// Continue removing the remaining listeners independently.
-			}
-		}
 	}
 
 	private _cleanupProxy(proxy: TProxy): void {
@@ -1168,18 +1121,18 @@ export class WorkerPool<
 
 	private _rejectQueueIfPermanentlyExhausted(): void {
 		if (
-			this.terminationStarted ||
+			this.shutdownStarted ||
 			this.queue.length === 0 ||
 			this.workers.length > 0 ||
-			this.workers.length + this.termination.count < this.physicalWorkerLimit ||
-			this.termination.hasRetryableWorker()
+			this.workers.length + this.disposal.count < this.physicalHandleLimit ||
+			this.disposal.hasRetryableHandle()
 		) {
 			return;
 		}
 
 		const error = new WorkerPoolCapacityError(
-			this.physicalWorkerLimit,
-			this.termination.count,
+			this.physicalHandleLimit,
+			this.disposal.count,
 		);
 		for (const item of this.queue.drain()) {
 			this._settleTask(item, false, error);
@@ -1189,7 +1142,7 @@ export class WorkerPool<
 	private _updateStats(): void {
 		if (
 			this.drainRequested &&
-			!this.terminationStarted &&
+			!this.shutdownStarted &&
 			this.workerCreationsInProgress === 0 &&
 			this.queue.length === 0 &&
 			this.workers.every((worker) => worker.activeTasks.size === 0)
@@ -1198,17 +1151,17 @@ export class WorkerPool<
 			return;
 		}
 		if (
-			this.terminationStarted &&
+			this.shutdownStarted &&
 			!this.shutdownResolved &&
 			this.workerCreationsInProgress === 0 &&
 			this.workers.length === 0 &&
-			this.termination.allExhausted()
+			this.disposal.allExhausted()
 		) {
 			this.shutdownResolved = true;
 			this.resolveTerminated({
-				confirmed: this.termination.count === 0,
-				unconfirmedWorkers: this.termination.count,
-				terminationFailures: this.termination.failures,
+				confirmed: this.disposal.count === 0,
+				unconfirmedWorkers: this.disposal.count,
+				terminationFailures: this.disposal.failures,
 			});
 		}
 		if (!this.onUpdate) return;

--- a/packages/comlink-worker-pool/src/contracts.ts
+++ b/packages/comlink-worker-pool/src/contracts.ts
@@ -96,7 +96,7 @@ export type WorkerPoolEvent =
 export interface WorkerPoolStats {
 	/** Current acceptance and shutdown state. */
 	state: WorkerPoolState;
-	/** Configured maximum number of scheduler-managed, non-quarantined workers. */
+	/** Configured maximum number of scheduler-managed, non-quarantined handles. */
 	size: number;
 	/** Configured maximum number of simultaneously running tasks. */
 	maxConcurrentTasks: number;
@@ -110,15 +110,15 @@ export interface WorkerPoolStats {
 	queueCapacityRemaining: number | null;
 	/** Age of the oldest waiting task, or null when the queue is empty. */
 	oldestQueuedTaskAgeMs: number | null;
-	/** Number of currently instantiated workers. */
+	/** Number of instantiated or quarantined worker handles. */
 	workers: number;
-	/** Scheduler-managed workers, including busy workers finishing before retirement. */
+	/** Scheduler-managed handles, including busy handles finishing before retirement. */
 	healthyWorkers: number;
-	/** Number of removed workers whose termination is not yet confirmed. */
+	/** Number of removed handles whose cleanup is not yet confirmed. */
 	quarantinedWorkers: number;
-	/** Configured extra physical-worker allowance for quarantined workers. */
+	/** Configured extra handle allowance for cleanup failures. */
 	terminationFailureWorkerBuffer: number;
-	/** Cumulative number of failed or timed-out termination attempts. */
+	/** Cumulative number of failed or timed-out handle cleanup attempts. */
 	terminationFailures: number;
 	/** Number of workers with no running tasks. */
 	idleWorkers: number;
@@ -144,11 +144,14 @@ export interface WorkerPoolStats {
 
 /** Final outcome of an awaitable WorkerPool shutdown. */
 export interface WorkerPoolShutdownReport {
-	/** True when termination was confirmed for every worker. */
+	/**
+	 * True when cleanup completed for every pool-owned handle. SharedWorker
+	 * cleanup confirms connection disposal, not termination of the shared process.
+	 */
 	confirmed: boolean;
-	/** Workers whose termination could not be confirmed after all retries. */
+	/** Worker handles whose cleanup could not be confirmed after all retries. */
 	unconfirmedWorkers: number;
-	/** Cumulative failed or timed-out termination attempts. */
+	/** Cumulative failed or timed-out handle cleanup attempts. */
 	terminationFailures: number;
 }
 
@@ -161,7 +164,7 @@ export interface Task<TTask, TResult> {
 
 /** Options shared by dedicated-worker and SharedWorker pools. */
 interface WorkerPoolCommonOptions<TProxy extends CallableProxy<TProxy>> {
-	/** Maximum number of scheduler-managed, non-quarantined workers. */
+	/** Maximum number of scheduler-managed, non-quarantined handles. */
 	size: number;
 	/** Optional callback for pool statistics. Observer errors do not break the pool. */
 	onUpdateStats?: WorkerPoolObserver<WorkerPoolStats>;
@@ -182,27 +185,27 @@ interface WorkerPoolCommonOptions<TProxy extends CallableProxy<TProxy>> {
 	/** Default maximum queue wait; false or undefined disables it. */
 	queueTimeoutMs?: number | false;
 	/**
-	 * Rejects a task that runs longer than this duration and recycles its worker.
-	 * Defaults to five minutes because this is the only portable way to recover
-	 * from a worker that silently closes. Set to false for intentionally unbounded
-	 * jobs, accepting that a silent worker exit can then leave work pending.
+	 * Rejects a task that runs longer than this duration and recycles its handle.
+	 * Defaults to five minutes because this is the portable recovery path for a
+	 * silent endpoint. Dedicated-worker cleanup stops that worker; SharedWorker
+	 * cleanup closes only the pool's connection, so remote work may continue.
+	 * Set to false for intentionally unbounded jobs.
 	 */
 	taskTimeoutMs?: number | false;
 	/** Optional cleanup for resources owned by a proxy (for example Comlink.releaseProxy). */
 	proxyCleanup?: (proxy: TProxy) => void;
 	/**
-	 * Extra physical-worker allowance used to preserve healthy capacity while
-	 * removed workers have unconfirmed termination. Defaults to
-	 * max(2, floor(size / 2)).
+	 * Extra handle allowance used to preserve healthy capacity while removed
+	 * handles have unconfirmed cleanup. Defaults to max(2, floor(size / 2)).
 	 */
 	terminationFailureWorkerBuffer?: number;
-	/** Additional termination attempts after the initial attempt. Defaults to 3. */
+	/** Additional handle-cleanup attempts after the initial attempt. Defaults to 3. */
 	terminationRetryAttempts?: number;
-	/** Initial retry delay; subsequent delays use exponential backoff. Defaults to 100ms. */
+	/** Initial cleanup retry delay; later delays use exponential backoff. Defaults to 100ms. */
 	terminationRetryDelayMs?: number;
-	/** Absolute deadline for each asynchronous termination attempt. Defaults to 5 seconds. */
+	/** Absolute deadline for each asynchronous cleanup attempt. Defaults to 5 seconds. */
 	terminationAttemptTimeoutMs?: number;
-	/** Receives isolated termination-attempt failures. */
+	/** Receives isolated handle-cleanup failures. */
 	onWorkerTerminationError?: WorkerPoolObserver<WorkerTerminationError>;
 }
 
@@ -210,11 +213,11 @@ interface WorkerPoolEndpointOptions<
 	TProxy extends CallableProxy<TProxy>,
 	TWorker extends WorkerHandle,
 > {
-	/** Creates a fresh worker whose lifecycle is owned by the pool. */
+	/** Creates a fresh worker handle whose lifecycle is owned by the pool. */
 	workerFactory: WorkerFactory<TWorker>;
-	/** Creates the API proxy associated with the worker. */
+	/** Creates the API proxy associated with the handle. */
 	proxyFactory: (worker: TWorker) => TProxy;
-	/** Optional host-specific termination implementation. */
+	/** Optional host-specific handle cleanup implementation. */
 	workerTerminator?: WorkerTerminator<TWorker>;
 }
 

--- a/packages/comlink-worker-pool/src/errors.ts
+++ b/packages/comlink-worker-pool/src/errors.ts
@@ -30,7 +30,7 @@ export class WorkerTaskTimeoutError extends Error {
 	}
 }
 
-/** Error reported when a worker termination attempt fails or times out. */
+/** Error reported when cleanup through workerTerminator fails or times out. */
 export class WorkerTerminationError extends Error {
 	readonly workerId: number | undefined;
 	readonly attempt: number;
@@ -56,7 +56,7 @@ export class WorkerTerminationError extends Error {
 	}
 }
 
-/** Error returned when quarantined workers consume all physical capacity. */
+/** Error returned when quarantined worker handles consume all capacity. */
 export class WorkerPoolCapacityError extends Error {
 	readonly physicalWorkerLimit: number;
 	readonly quarantinedWorkers: number;

--- a/packages/comlink-worker-pool/src/internal/disposal.ts
+++ b/packages/comlink-worker-pool/src/internal/disposal.ts
@@ -1,18 +1,14 @@
 import { WorkerTerminationError } from "../errors";
-import type {
-	BoundWorkerTerminator,
-	WorkerHandle,
-	WorkerTerminationResult,
-} from "../worker";
+import type { BoundWorkerDisposer, WorkerTerminationResult } from "../worker";
 import { MAX_TIMER_DELAY_MS, monotonicNow } from "./lifecycle";
 
-export const DEFAULT_TERMINATION_RETRY_ATTEMPTS = 3;
-export const DEFAULT_TERMINATION_RETRY_DELAY_MS = 100;
-export const DEFAULT_TERMINATION_ATTEMPT_TIMEOUT_MS = 5_000;
+export const DEFAULT_DISPOSAL_RETRY_ATTEMPTS = 3;
+export const DEFAULT_DISPOSAL_RETRY_DELAY_MS = 100;
+export const DEFAULT_DISPOSAL_ATTEMPT_TIMEOUT_MS = 5_000;
 
-export interface TerminationRecord {
-	worker: WorkerHandle;
-	terminate: BoundWorkerTerminator;
+export interface DisposalRecord {
+	identity: object;
+	dispose: BoundWorkerDisposer;
 	workerId: number | undefined;
 	attempts: number;
 	exhausted: boolean;
@@ -20,7 +16,7 @@ export interface TerminationRecord {
 	attemptTimers: Set<ReturnType<typeof setTimeout>>;
 }
 
-export interface TerminationControllerOptions {
+export interface DisposalControllerOptions {
 	retryAttempts: number;
 	retryDelayMs: number;
 	attemptTimeoutMs: number;
@@ -28,12 +24,12 @@ export interface TerminationControllerOptions {
 	onStateChange: () => void;
 }
 
-/** Owns quarantine, retry, deadline, and confirmation state for removed workers. */
-export class TerminationController {
-	private readonly records = new Map<WorkerHandle, TerminationRecord>();
+/** Owns quarantine, retry, deadline, and confirmation state for handle cleanup. */
+export class DisposalController {
+	private readonly records = new Map<object, DisposalRecord>();
 	private failureCount = 0;
 
-	constructor(private readonly options: TerminationControllerOptions) {}
+	constructor(private readonly options: DisposalControllerOptions) {}
 
 	get count(): number {
 		return this.records.size;
@@ -50,7 +46,7 @@ export class TerminationController {
 		return true;
 	}
 
-	hasRetryableWorker(): boolean {
+	hasRetryableHandle(): boolean {
 		for (const record of this.records.values()) {
 			if (!record.exhausted) return true;
 		}
@@ -58,27 +54,27 @@ export class TerminationController {
 	}
 
 	quarantine(
-		worker: WorkerHandle,
-		terminate: BoundWorkerTerminator,
+		identity: object,
+		dispose: BoundWorkerDisposer,
 		workerId?: number,
-	): TerminationRecord {
-		const existing = this.records.get(worker);
+	): DisposalRecord {
+		const existing = this.records.get(identity);
 		if (existing) return existing;
 
-		const record: TerminationRecord = {
-			worker,
-			terminate,
+		const record: DisposalRecord = {
+			identity,
+			dispose,
 			workerId,
 			attempts: 0,
 			exhausted: false,
 			attemptTimers: new Set(),
 		};
-		this.records.set(worker, record);
+		this.records.set(identity, record);
 		return record;
 	}
 
-	attempt(record: TerminationRecord): void {
-		if (this.records.get(record.worker) !== record) return;
+	attempt(record: DisposalRecord): void {
+		if (this.records.get(record.identity) !== record) return;
 		record.retryTimer = undefined;
 		record.exhausted = false;
 		record.attempts++;
@@ -86,7 +82,7 @@ export class TerminationController {
 
 		let result: WorkerTerminationResult;
 		try {
-			result = record.terminate();
+			result = record.dispose();
 		} catch (error) {
 			this.recordFailure(record, error);
 			return;
@@ -139,7 +135,7 @@ export class TerminationController {
 		const confirm = () => {
 			if (attemptFinished) {
 				if (timedOut) {
-					// A late success still confirms that the worker is gone.
+					// A late success still confirms that handle cleanup completed.
 					this.confirm(record);
 				}
 				return;
@@ -181,17 +177,17 @@ export class TerminationController {
 		}
 	}
 
-	private confirm(record: TerminationRecord): void {
-		if (this.records.get(record.worker) !== record) return;
+	private confirm(record: DisposalRecord): void {
+		if (this.records.get(record.identity) !== record) return;
 		if (record.retryTimer !== undefined) clearTimeout(record.retryTimer);
 		for (const timer of record.attemptTimers) clearTimeout(timer);
 		record.attemptTimers.clear();
-		this.records.delete(record.worker);
+		this.records.delete(record.identity);
 		this.options.onStateChange();
 	}
 
-	private recordFailure(record: TerminationRecord, cause: unknown): void {
-		if (this.records.get(record.worker) !== record) return;
+	private recordFailure(record: DisposalRecord, cause: unknown): void {
+		if (this.records.get(record.identity) !== record) return;
 		this.failureCount++;
 		const exhausted = record.attempts > this.options.retryAttempts;
 		record.exhausted = exhausted;

--- a/packages/comlink-worker-pool/src/internal/lifecycle.ts
+++ b/packages/comlink-worker-pool/src/internal/lifecycle.ts
@@ -1,10 +1,5 @@
-import type { BoundWorkerTerminator, WorkerHandle } from "../worker";
+import type { BoundWorkerDisposer } from "../worker";
 import type { ScheduledTask } from "./scheduler";
-
-export interface WorkerFailureListenerRegistration {
-	target: EventTarget;
-	type: string;
-}
 
 export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 export const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
@@ -12,8 +7,9 @@ export const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
 export interface WorkerMetadata<TProxy, TTask, TResult> {
 	id: number;
 	proxy: TProxy;
-	worker: WorkerHandle;
-	terminate: BoundWorkerTerminator;
+	identity: object;
+	dispose: BoundWorkerDisposer;
+	unsubscribeFailures: () => void;
 	taskCount: number;
 	createdAt: number;
 	activeTasks: Set<ScheduledTask<TTask, TResult>>;
@@ -24,8 +20,6 @@ export interface WorkerMetadata<TProxy, TTask, TResult> {
 	idleTimer?: ReturnType<typeof setTimeout>;
 	idleDeadline?: number;
 	lifetimeTimer?: ReturnType<typeof setTimeout>;
-	failureHandler: (event: Event) => void;
-	failureListeners: WorkerFailureListenerRegistration[];
 }
 
 /** Consumes a callback's optional thenable so asynchronous failures stay isolated. */

--- a/packages/comlink-worker-pool/src/worker.ts
+++ b/packages/comlink-worker-pool/src/worker.ts
@@ -1,25 +1,43 @@
-/** A worker object whose lifecycle is owned by the pool. */
+/** A dedicated worker or SharedWorker connection handle owned by the pool. */
 export type WorkerHandle = Worker | SharedWorker;
 
 /** Factory for creating a fresh worker handle. */
 export type WorkerFactory<TWorker extends WorkerHandle = Worker> =
 	() => TWorker;
 
-/** Result of a synchronous or asynchronous worker termination. */
-// biome-ignore lint/suspicious/noConfusingVoidType: sync terminators naturally return void.
+/** Result of synchronous or asynchronous cleanup for a worker handle. */
+// biome-ignore lint/suspicious/noConfusingVoidType: synchronous cleanup naturally returns void.
 export type WorkerTerminationResult = void | PromiseLike<unknown>;
 
-/** Terminates a worker and resolves only when termination is confirmed. */
+/**
+ * Releases a pool-owned worker handle.
+ *
+ * Completion confirms the cleanup operation. For a SharedWorker, it does not
+ * imply that the shared process ended; the default cleanup closes only this
+ * handle's connection port.
+ */
 export type WorkerTerminator<TWorker extends WorkerHandle = Worker> = (
 	worker: TWorker,
 ) => WorkerTerminationResult;
 
-/** A bound termination operation for one worker instance. */
-export type BoundWorkerTerminator = () => WorkerTerminationResult;
+/** A bound cleanup operation for one pool-owned worker handle. */
+export type BoundWorkerDisposer = () => WorkerTerminationResult;
 
-export interface WorkerFailureTarget {
-	target: EventTarget;
-	eventTypes: readonly string[];
+/** Removes every failure listener registered for a worker handle. */
+export type WorkerFailureUnsubscribe = () => void;
+
+/** Platform-neutral lifecycle boundary consumed by the scheduler. */
+export interface WorkerLease<TProxy> {
+	/** Stable identity used for freshness checks and cleanup quarantine. */
+	identity: object;
+	/** Creates the API proxy after failure observation is active. */
+	createProxy: () => TProxy;
+	/** Observes all failure sources and returns idempotent cleanup. */
+	subscribeToFailures: (
+		listener: (event: Event) => void,
+	) => WorkerFailureUnsubscribe;
+	/** Releases the resources owned through this handle. */
+	dispose: BoundWorkerDisposer;
 }
 
 const DEDICATED_WORKER_FAILURE_EVENT_TYPES = ["error", "messageerror"] as const;
@@ -33,29 +51,96 @@ function isDedicatedWorker(worker: WorkerHandle): worker is Worker {
 	return "terminate" in worker;
 }
 
-/** Returns every event source that can report failure for a worker. */
-export function getWorkerFailureTargets(
+function getWorkerFailureTargets(
 	worker: WorkerHandle,
-): WorkerFailureTarget[] {
+): Array<readonly [EventTarget, readonly string[]]> {
 	if (isDedicatedWorker(worker)) {
-		return [
-			{ target: worker, eventTypes: DEDICATED_WORKER_FAILURE_EVENT_TYPES },
-		];
+		return [[worker, DEDICATED_WORKER_FAILURE_EVENT_TYPES]];
 	}
 	return [
-		{ target: worker, eventTypes: SHARED_WORKER_FAILURE_EVENT_TYPES },
-		{
-			target: worker.port,
-			eventTypes: SHARED_WORKER_PORT_FAILURE_EVENT_TYPES,
-		},
+		[worker, SHARED_WORKER_FAILURE_EVENT_TYPES],
+		[worker.port, SHARED_WORKER_PORT_FAILURE_EVENT_TYPES],
 	];
 }
 
-/** Applies the platform-default termination behavior for a worker. */
-export function terminateWorker(worker: WorkerHandle): void {
+function subscribeToWorkerFailures(
+	worker: WorkerHandle,
+	listener: (event: Event) => void,
+): WorkerFailureUnsubscribe {
+	const registrations: Array<readonly [EventTarget, string]> = [];
+	let active = true;
+	let subscribing = true;
+	let synchronousFailureObserved = false;
+	const forwardingListener = (event: Event) => {
+		if (subscribing) synchronousFailureObserved = true;
+		listener(event);
+	};
+	const unsubscribe = () => {
+		if (!active) return;
+		active = false;
+		for (const [target, type] of registrations.splice(0)) {
+			try {
+				target.removeEventListener(type, forwardingListener);
+			} catch {
+				// Continue removing the remaining listeners independently.
+			}
+		}
+	};
+
+	try {
+		registration: for (const [target, eventTypes] of getWorkerFailureTargets(
+			worker,
+		)) {
+			for (const type of eventTypes) {
+				registrations.push([target, type]);
+				target.addEventListener(type, forwardingListener);
+				if (synchronousFailureObserved) break registration;
+			}
+		}
+	} catch (error) {
+		unsubscribe();
+		throw error;
+	} finally {
+		subscribing = false;
+	}
+
+	return unsubscribe;
+}
+
+function disposeWorkerHandle(worker: WorkerHandle): void {
 	if (isDedicatedWorker(worker)) {
 		worker.terminate();
 		return;
 	}
 	worker.port.close();
+}
+
+function assertWorkerHandle(worker: WorkerHandle): void {
+	if ((typeof worker !== "object" && typeof worker !== "function") || !worker) {
+		throw new TypeError(
+			"workerFactory must return a Worker or SharedWorker object",
+		);
+	}
+}
+
+/** Normalizes a concrete worker configuration into scheduler-owned leases. */
+export function createWorkerLeaseFactory<TProxy, TWorker extends WorkerHandle>(
+	workerFactory: WorkerFactory<TWorker>,
+	proxyFactory: (worker: TWorker) => TProxy,
+	workerTerminator?: WorkerTerminator<TWorker>,
+): () => WorkerLease<TProxy> {
+	return () => {
+		const worker = workerFactory();
+		assertWorkerHandle(worker);
+		return {
+			identity: worker,
+			createProxy: () => proxyFactory(worker),
+			subscribeToFailures: (listener) =>
+				subscribeToWorkerFailures(worker, listener),
+			dispose: () =>
+				workerTerminator
+					? workerTerminator(worker)
+					: disposeWorkerHandle(worker),
+		};
+	};
 }

--- a/scripts/fixtures/package-consumer/cjs.cjs
+++ b/scripts/fixtures/package-consumer/cjs.cjs
@@ -1,0 +1,11 @@
+const core = require("comlink-worker-pool");
+const react = require("comlink-worker-pool-react");
+
+if (
+	typeof core.WorkerPool !== "function" ||
+	typeof core.WorkerPoolQueueFullError !== "function" ||
+	typeof react.useWorkerPool !== "function" ||
+	typeof react.useWorkerTask !== "function"
+) {
+	process.exit(1);
+}

--- a/scripts/fixtures/package-consumer/consumer.ts
+++ b/scripts/fixtures/package-consumer/consumer.ts
@@ -1,0 +1,155 @@
+import {
+	type PooledApi,
+	type SharedWorkerPoolOptions,
+	WorkerPool,
+	type WorkerPoolShutdownReport,
+} from "comlink-worker-pool";
+import {
+	type UseSharedWorkerPoolOptions,
+	useWorkerPool,
+	useWorkerTask,
+} from "comlink-worker-pool-react";
+
+interface Api {
+	add(a: number, b: number): Promise<number>;
+}
+
+interface SyncApi {
+	sync(value: number): number;
+	then(): Promise<void>;
+	[Symbol.iterator](): Iterator<number>;
+}
+
+interface StringIndexedApi {
+	[method: string]: () => number;
+}
+
+declare const workerFactory: () => Worker;
+declare const proxyFactory: (worker: Worker) => Api;
+declare const sharedWorkerFactory: () => SharedWorker;
+declare const sharedProxyFactory: (worker: SharedWorker) => Api;
+declare const syncProxyFactory: (worker: Worker) => SyncApi;
+declare const stringIndexedProxyFactory: (worker: Worker) => StringIndexedApi;
+
+const pool = new WorkerPool<Api>({
+	size: 1,
+	workerFactory,
+	proxyFactory,
+	maxQueueSize: 2,
+});
+const result: Promise<number> = pool.run("add", [1, 2], { priority: 1 });
+const shutdown: Promise<WorkerPoolShutdownReport> = pool.drain();
+
+const sharedOptions: SharedWorkerPoolOptions<Api> = {
+	size: 1,
+	workerFactory: sharedWorkerFactory,
+	proxyFactory: sharedProxyFactory,
+	maxConcurrentTasksPerWorker: 2,
+	workerTerminator: (worker) => worker.port.close(),
+};
+const sharedPool = new WorkerPool<Api>(sharedOptions);
+
+// Keep these callbacks inline: this verifies constructor contextual inference.
+const inferredSharedPool = new WorkerPool<Api>({
+	size: 1,
+	workerFactory: sharedWorkerFactory,
+	proxyFactory: (worker) => {
+		const port: MessagePort = worker.port;
+		void port;
+		return sharedProxyFactory(worker);
+	},
+	workerTerminator: (worker) => worker.port.close(),
+});
+
+const syncPool = new WorkerPool<SyncApi>({
+	size: 1,
+	workerFactory,
+	proxyFactory: syncProxyFactory,
+});
+const pooledApi: PooledApi<SyncApi> = syncPool.getApi();
+const syncResult: Promise<number> = pooledApi.sync(1);
+const reservedResult: Promise<void> = syncPool.run("then", []);
+// @ts-expect-error Scheduled calls always return promises.
+const incorrectSyncResult: number = pooledApi.sync(1);
+// @ts-expect-error The then key is reserved on the scheduled proxy.
+pooledApi.then();
+// @ts-expect-error Symbol methods are not exposed by the scheduled proxy.
+pooledApi[Symbol.iterator]();
+
+const stringIndexedPool = new WorkerPool<StringIndexedApi>({
+	size: 1,
+	workerFactory,
+	proxyFactory: stringIndexedProxyFactory,
+});
+const stringIndexedApi: PooledApi<StringIndexedApi> =
+	stringIndexedPool.getApi();
+const stringIndexedResult: Promise<number> = stringIndexedApi.work();
+// @ts-expect-error The then key stays reserved for string-indexed scheduled APIs.
+stringIndexedApi.then();
+
+function useConsumerHooks() {
+	const hook = useWorkerPool<Api>({
+		workerFactory,
+		proxyFactory,
+		poolSize: 1,
+	});
+	const task = useWorkerTask(hook.api, "add");
+	const taskResult: number | null = task.result;
+
+	const sharedHookOptions: UseSharedWorkerPoolOptions<Api> = {
+		workerFactory: sharedWorkerFactory,
+		proxyFactory: sharedProxyFactory,
+		maxConcurrentTasksPerWorker: 2,
+		workerTerminator: (worker) => worker.port.close(),
+	};
+	const sharedHook = useWorkerPool<Api>(sharedHookOptions);
+
+	// Keep these callbacks inline: this verifies hook contextual inference.
+	const inferredSharedHook = useWorkerPool<Api>({
+		workerFactory: sharedWorkerFactory,
+		proxyFactory: (worker) => {
+			const port: MessagePort = worker.port;
+			void port;
+			return sharedProxyFactory(worker);
+		},
+		workerTerminator: (worker) => worker.port.close(),
+	});
+
+	const syncHook = useWorkerPool<SyncApi>({
+		workerFactory,
+		proxyFactory: syncProxyFactory,
+	});
+	const hookSyncResult: Promise<number> | undefined = syncHook.api?.sync(1);
+	const trackedSyncResult: Promise<number> = syncHook.call("sync", 1);
+	// @ts-expect-error The then key is reserved on the scheduled hook API.
+	syncHook.call("then");
+
+	const stringIndexedHook = useWorkerPool<StringIndexedApi>({
+		workerFactory,
+		proxyFactory: stringIndexedProxyFactory,
+	});
+	const stringIndexedHookResult: Promise<number> | undefined =
+		stringIndexedHook.api?.work();
+	const stringIndexedTrackedResult: Promise<number> =
+		stringIndexedHook.call("work");
+	// @ts-expect-error Tracked calls also reserve then for string-indexed APIs.
+	stringIndexedHook.call("then");
+
+	void taskResult;
+	void sharedHook;
+	void inferredSharedHook;
+	void hookSyncResult;
+	void trackedSyncResult;
+	void stringIndexedHookResult;
+	void stringIndexedTrackedResult;
+}
+
+void result;
+void shutdown;
+void sharedPool;
+void inferredSharedPool;
+void syncResult;
+void reservedResult;
+void incorrectSyncResult;
+void stringIndexedResult;
+void useConsumerHooks;

--- a/scripts/fixtures/package-consumer/esm.mjs
+++ b/scripts/fixtures/package-consumer/esm.mjs
@@ -1,0 +1,11 @@
+import { WorkerPool, WorkerPoolQueueFullError } from "comlink-worker-pool";
+import { useWorkerPool, useWorkerTask } from "comlink-worker-pool-react";
+
+if (
+	typeof WorkerPool !== "function" ||
+	typeof WorkerPoolQueueFullError !== "function" ||
+	typeof useWorkerPool !== "function" ||
+	typeof useWorkerTask !== "function"
+) {
+	process.exit(1);
+}

--- a/scripts/fixtures/package-consumer/tsconfig.json
+++ b/scripts/fixtures/package-consumer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"lib": ["ES2022", "DOM"],
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"noEmit": true,
+		"strict": true,
+		"target": "ES2022"
+	},
+	"include": ["consumer.ts"]
+}

--- a/scripts/smoke-package-consumer.mjs
+++ b/scripts/smoke-package-consumer.mjs
@@ -1,10 +1,28 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, "..");
+const consumerFixtureDirectory = join(
+	scriptDirectory,
+	"fixtures",
+	"package-consumer",
+);
+const consumerFixtureFiles = [
+	"esm.mjs",
+	"cjs.cjs",
+	"consumer.ts",
+	"tsconfig.json",
+];
 const temporaryDirectory = mkdtempSync(join(tmpdir(), "worker-pool-consumer-"));
 
 function execute(command, args, cwd = workspaceRoot) {
@@ -27,33 +45,13 @@ function pack(packageDirectory) {
 	return join(temporaryDirectory, filename);
 }
 
-function writeConsumerFiles(directory) {
-	writeFileSync(
-		join(directory, "esm.mjs"),
-		'import { WorkerPool, WorkerPoolQueueFullError } from "comlink-worker-pool";\nimport { useWorkerPool, useWorkerTask } from "comlink-worker-pool-react";\nif (typeof WorkerPool !== "function" || typeof WorkerPoolQueueFullError !== "function" || typeof useWorkerPool !== "function" || typeof useWorkerTask !== "function") process.exit(1);\n',
-	);
-	writeFileSync(
-		join(directory, "cjs.cjs"),
-		'const core = require("comlink-worker-pool");\nconst react = require("comlink-worker-pool-react");\nif (typeof core.WorkerPool !== "function" || typeof core.WorkerPoolQueueFullError !== "function" || typeof react.useWorkerPool !== "function" || typeof react.useWorkerTask !== "function") process.exit(1);\n',
-	);
-	writeFileSync(
-		join(directory, "consumer.ts"),
-		'import { WorkerPool, type PooledApi, type SharedWorkerPoolOptions, type WorkerPoolShutdownReport } from "comlink-worker-pool";\nimport { type UseSharedWorkerPoolOptions, useWorkerPool, useWorkerTask } from "comlink-worker-pool-react";\ninterface Api { add(a: number, b: number): Promise<number> }\ninterface SyncApi { sync(value: number): number; then(): Promise<void>; [Symbol.iterator](): Iterator<number> }\ninterface StringIndexedApi { [method: string]: () => number }\ndeclare const workerFactory: () => Worker;\ndeclare const proxyFactory: (worker: Worker) => Api;\ndeclare const sharedWorkerFactory: () => SharedWorker;\ndeclare const sharedProxyFactory: (worker: SharedWorker) => Api;\ndeclare const syncProxyFactory: (worker: Worker) => SyncApi;\ndeclare const stringIndexedProxyFactory: (worker: Worker) => StringIndexedApi;\nconst pool = new WorkerPool<Api>({ size: 1, workerFactory, proxyFactory, maxQueueSize: 2 });\nconst result: Promise<number> = pool.run("add", [1, 2], { priority: 1 });\nconst shutdown: Promise<WorkerPoolShutdownReport> = pool.drain();\nconst hook = useWorkerPool<Api>({ workerFactory, proxyFactory, poolSize: 1 });\nconst sharedOptions: SharedWorkerPoolOptions<Api> = { size: 1, workerFactory: sharedWorkerFactory, proxyFactory: sharedProxyFactory, maxConcurrentTasksPerWorker: 2, workerTerminator: (worker) => worker.port.close() };\nconst sharedPool = new WorkerPool<Api>(sharedOptions);\nconst sharedHookOptions: UseSharedWorkerPoolOptions<Api> = { workerFactory: sharedWorkerFactory, proxyFactory: sharedProxyFactory, maxConcurrentTasksPerWorker: 2, workerTerminator: (worker) => worker.port.close() };\nconst sharedHook = useWorkerPool<Api>(sharedHookOptions);\nconst task = useWorkerTask(hook.api, "add");\nconst taskResult: number | null = task.result;\nconst syncPool = new WorkerPool<SyncApi>({ size: 1, workerFactory, proxyFactory: syncProxyFactory });\nconst pooledApi: PooledApi<SyncApi> = syncPool.getApi();\nconst syncResult: Promise<number> = pooledApi.sync(1);\nconst reservedResult: Promise<void> = syncPool.run("then", []);\n// @ts-expect-error Scheduled calls always return promises.\nconst incorrectSyncResult: number = pooledApi.sync(1);\n// @ts-expect-error The then key is reserved on the scheduled proxy.\npooledApi.then();\n// @ts-expect-error Symbol methods are not exposed by the scheduled proxy.\npooledApi[Symbol.iterator]();\nconst syncHook = useWorkerPool<SyncApi>({ workerFactory, proxyFactory: syncProxyFactory });\nconst hookSyncResult: Promise<number> | undefined = syncHook.api?.sync(1);\nconst trackedSyncResult: Promise<number> = syncHook.call("sync", 1);\n// @ts-expect-error The then key is reserved on the scheduled hook API.\nsyncHook.call("then");\nconst stringIndexedPool = new WorkerPool<StringIndexedApi>({ size: 1, workerFactory, proxyFactory: stringIndexedProxyFactory });\nconst stringIndexedApi: PooledApi<StringIndexedApi> = stringIndexedPool.getApi();\nconst stringIndexedResult: Promise<number> = stringIndexedApi.work();\n// @ts-expect-error The then key stays reserved for string-indexed scheduled APIs.\nstringIndexedApi.then();\nconst stringIndexedHook = useWorkerPool<StringIndexedApi>({ workerFactory, proxyFactory: stringIndexedProxyFactory });\nconst stringIndexedHookResult: Promise<number> | undefined = stringIndexedHook.api?.work();\nconst stringIndexedTrackedResult: Promise<number> = stringIndexedHook.call("work");\n// @ts-expect-error Tracked calls also reserve then for string-indexed APIs.\nstringIndexedHook.call("then");\nvoid result;\nvoid shutdown;\nvoid taskResult;\nvoid sharedPool;\nvoid sharedHook;\nvoid syncResult;\nvoid reservedResult;\nvoid incorrectSyncResult;\nvoid hookSyncResult;\nvoid trackedSyncResult;\nvoid stringIndexedResult;\nvoid stringIndexedHookResult;\nvoid stringIndexedTrackedResult;\n',
-	);
-	writeFileSync(
-		join(directory, "tsconfig.json"),
-		JSON.stringify({
-			compilerOptions: {
-				lib: ["ES2022", "DOM"],
-				module: "NodeNext",
-				moduleResolution: "NodeNext",
-				noEmit: true,
-				strict: true,
-				target: "ES2022",
-			},
-			include: ["consumer.ts"],
-		}),
-	);
+function copyConsumerFixtures(directory) {
+	for (const filename of consumerFixtureFiles) {
+		copyFileSync(
+			join(consumerFixtureDirectory, filename),
+			join(directory, filename),
+		);
+	}
 }
 
 try {
@@ -89,7 +87,7 @@ try {
 			],
 			consumerDirectory,
 		);
-		writeConsumerFiles(consumerDirectory);
+		copyConsumerFixtures(consumerDirectory);
 		execute("node", ["esm.mjs"], consumerDirectory);
 		execute("node", ["cjs.cjs"], consumerDirectory);
 		execute(

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -7,5 +7,6 @@
 		"playwright.config.ts",
 		"scripts/**/*.ts",
 		"packages/*/*.config.ts"
-	]
+	],
+	"exclude": ["scripts/fixtures/**"]
 }


### PR DESCRIPTION
## Summary

- normalize dedicated workers and SharedWorker connections behind a scheduler-facing lease boundary
- model internal shutdown work as handle disposal while preserving the existing public termination API names
- clarify SharedWorker cleanup semantics in the core and React documentation
- extract package-consumer fixtures and verify contextual SharedWorker callback inference

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run test:coverage`
- `bun run audit`
- `bun run build`
- `bun run test:packages`
- `bun run benchmark:runtime`
- `bun run benchmark:bundle`
- `bun run playground:build`
- `bun run test:browser` (14 passed, 1 expected skip)
